### PR TITLE
fix(pinia): passing `getters` on `inspectorStateUpdated`

### DIFF
--- a/packages/core/src/bridge/devtools.ts
+++ b/packages/core/src/bridge/devtools.ts
@@ -52,6 +52,7 @@ export class BridgeRpc {
         const _payload = parse(payload)
         options.inspectorId === _payload.inspectorId && cb({
           state: _payload.state,
+          getters: _payload.getters,
         } as T)
       })
     },

--- a/packages/playground/src/App.preview.vue
+++ b/packages/playground/src/App.preview.vue
@@ -16,6 +16,9 @@ const app = useAppStore()
     <p>
       Pinia State Count: {{ app.count }}
     </p>
+    <p>
+      Pinia Getter DoubledCount: {{ app.doubledCount }}
+    </p>
     <button @click="app.increment">
       Increment Count (Pinia)
     </button>

--- a/packages/playground/src/stores/index.ts
+++ b/packages/playground/src/stores/index.ts
@@ -1,13 +1,14 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 export const useAppStore = defineStore('app', () => {
   const count = ref(120)
   function increment() {
     count.value++
   }
+  const doubledCount = computed(() => count.value * 2)
 
-  return { count, increment }
+  return { count, doubledCount, increment }
 })
 
 export const useCounterStore = defineStore('counter', () => {


### PR DESCRIPTION
fix: #121

Deserialize the getters from Pinia's `inspector-state:send` payload.

to be:
https://github.com/vuejs/devtools-next/assets/22590005/c7ff849d-eb51-4249-9d3a-3930468b4fdc

