### PR TITLE
chore(docs): changed brand button text color for better contrast

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -79,10 +79,10 @@
   --vp-button-brand-text: var(--vp-c-black);
   --vp-button-brand-bg: var(--vp-c-brand-3);
   --vp-button-brand-hover-border: transparent;
-  --vp-button-brand-hover-text: var(--vp-c-white);
+  --vp-button-brand-hover-text: var(--vp-c-black);
   --vp-button-brand-hover-bg: var(--vp-c-brand-2);
   --vp-button-brand-active-border: transparent;
-  --vp-button-brand-active-text: var(--vp-c-white);
+  --vp-button-brand-active-text: var(--vp-c-black);
   --vp-button-brand-active-bg: var(--vp-c-brand-1);
 }
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -76,7 +76,7 @@
 
 :root {
   --vp-button-brand-border: transparent;
-  --vp-button-brand-text: var(--vp-c-white);
+  --vp-button-brand-text: var(--vp-c-black);
   --vp-button-brand-bg: var(--vp-c-brand-3);
   --vp-button-brand-hover-border: transparent;
   --vp-button-brand-hover-text: var(--vp-c-white);


### PR DESCRIPTION
The contrast is really bad (under A, see https://coolors.co/contrast-checker/ffffff-46e392) for the brand button (Get Started button on the index page), as seen in the screenshot bellow:

![image](https://github.com/vuejs/devtools-next/assets/110247388/0c8460e5-d3ab-4b03-8100-6ffee6811862)

[![image](https://github.com/vuejs/devtools-next/assets/110247388/78cf5000-194a-4fb9-883f-f74e1ac57ae5)](https://coolors.co/contrast-checker/ffffff-46e392)


To fix it, I've changed the button's text to black (--vp-c-black) that improves the buttons contrast to over AAA (see https://coolors.co/contrast-checker/000000-46e392)

![image](https://github.com/vuejs/devtools-next/assets/110247388/90b9e3d8-1bda-4ba7-bfeb-985b83ba09c8)

