### PR TITLE
fix(client): sort error of pinned tabs

### DIFF
--- a/packages/client/src/composables/state-tab.ts
+++ b/packages/client/src/composables/state-tab.ts
@@ -139,7 +139,7 @@ export function getCategorizedTabs(flattenTabs: MaybeRef<(CustomTab | ModuleBuil
     })
     const pinned = categories.find(([{ name }]) => name === 'pinned')
     if (pinned)
-      pinned.sort((a, b) => pinnedTabs.indexOf(a[0].name) - pinnedTabs.indexOf(b[0].name))
+      pinned[1].sort((a, b) => pinnedTabs.indexOf(a.name) - pinnedTabs.indexOf(b.name))
     return categories
   })
 }


### PR DESCRIPTION
Errors occur when there are pinned tabs and when the Scrollable Sidebar is canceled. After refreshing the page, the panel is broken. see video below:

https://github.com/vuejs/devtools-next/assets/3993028/c1f99c9f-46d9-423c-831f-d13389bf8f4c

