### PR TITLE
perf: use `Set.has` instead of `Array.includes`

### DIFF
--- a/packages/devtools-kit/src/core/component/state/constants.ts
+++ b/packages/devtools-kit/src/core/component/state/constants.ts
@@ -1,4 +1,4 @@
-export const vueBuiltins = [
+export const vueBuiltins = new Set([
   'nextTick',
   'defineComponent',
   'defineAsyncComponent',
@@ -50,7 +50,7 @@ export const vueBuiltins = [
   'resolveDirective',
   'withDirectives',
   'withModifiers',
-]
+])
 
 export const symbolRE = /^\[native Symbol Symbol\((.*)\)\]$/
 export const rawTypeRE = /^\[object (\w+)]$/

--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -131,7 +131,7 @@ function getStateTypeAndName(info: ReturnType<typeof getSetupStateType>) {
 function processSetupState(instance: VueAppInstance) {
   const raw = instance.devtoolsRawSetupState || {}
   return Object.keys(instance.setupState)
-    .filter(key => !vueBuiltins.includes(key) && key.split(/(?=[A-Z])/)[0] !== 'use')
+    .filter(key => !vueBuiltins.has(key) && key.split(/(?=[A-Z])/)[0] !== 'use')
     .map((key) => {
       const value = returnError(() => toRaw(instance.setupState[key])) as unknown as {
         render: Function


### PR DESCRIPTION
`Set.has` has O(1) performance, which is faster than `Array.includes`'s O(n).