### PR TITLE
fix(client): deserialize issue on editing custom property

### DIFF
--- a/packages/client/src/components/inspector/InspectorDataField/Actions.vue
+++ b/packages/client/src/components/inspector/InspectorDataField/Actions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { VueButton, VueDropdown, VueDropdownButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { getRawValue } from '@vue/devtools-kit'
 import type { InspectorState, InspectorStateEditorPayload } from '@vue/devtools-kit'
 import type { ButtonProps } from '@vue/devtools-ui/dist/types/src/components/Button'
 import { useDevToolsBridgeRpc } from '@vue/devtools-core'
@@ -28,9 +29,8 @@ const { copy, isSupported } = useClipboard()
 
 const popupVisible = ref(false)
 
-const dataType = computed(() => {
-  return typeof props.data.value
-})
+const rawValue = computed(() => getRawValue(props.data.value).value)
+const dataType = computed(() => typeof rawValue.value)
 
 const iconButtonProps = {
   flat: true,
@@ -77,7 +77,7 @@ function quickEdit(v: unknown, remove: boolean = false) {
           v-tooltip="{
             content: 'Add new value',
           }" v-bind="iconButtonProps" :class="buttonClass" @click.stop="
-            $emit('addNewProp', Array.isArray(data.value) ? 'array' : 'object')"
+            $emit('addNewProp', Array.isArray(rawValue) ? 'array' : 'object')"
         >
           <template #icon>
             <VueIcon icon="i-material-symbols-add-circle-rounded" />
@@ -87,20 +87,20 @@ function quickEdit(v: unknown, remove: boolean = false) {
       <!-- checkbox, button value only -->
       <VueButton
         v-if="dataType === 'boolean'" v-bind="iconButtonProps" :class="buttonClass"
-        @click="quickEdit(!data.value)"
+        @click="quickEdit(!rawValue)"
       >
         <template #icon>
-          <VueIcon :icon="data.value ? 'i-material-symbols-check-box-sharp' : 'i-material-symbols-check-box-outline-blank-sharp'" />
+          <VueIcon :icon="rawValue ? 'i-material-symbols-check-box-sharp' : 'i-material-symbols-check-box-outline-blank-sharp'" />
         </template>
       </VueButton>
       <!-- increment/decrement button, numeric value only -->
       <template v-else-if="dataType === 'number'">
-        <VueButton v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit((data.value as number) + 1)">
+        <VueButton v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit((rawValue as number) + 1)">
           <template #icon>
             <VueIcon icon="i-carbon-add" />
           </template>
         </VueButton>
-        <VueButton v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit((data.value as number) - 1)">
+        <VueButton v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit((rawValue as number) - 1)">
           <template #icon>
             <VueIcon icon="i-carbon-subtract" />
           </template>
@@ -108,7 +108,7 @@ function quickEdit(v: unknown, remove: boolean = false) {
       </template>
     </template>
     <!-- delete prop, only appear if depth > 0 -->
-    <VueButton v-if="!props.disableEdit && depth > 0" v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit(data.value, true)">
+    <VueButton v-if="!props.disableEdit && depth > 0" v-bind="iconButtonProps" :class="buttonClass" @click="quickEdit(rawValue, true)">
       <template #icon>
         <VueIcon icon="i-material-symbols-delete-rounded" />
       </template>
@@ -128,7 +128,7 @@ function quickEdit(v: unknown, remove: boolean = false) {
       <template #popper>
         <div class="w160px py5px">
           <VueDropdownButton
-            @click="copy(dataType === 'object' ? JSON.stringify(data.value) : data.value.toString())"
+            @click="copy(dataType === 'object' ? JSON.stringify(rawValue) : rawValue.toString())"
           >
             <template #icon>
               <VueIcon icon="i-material-symbols-copy-all-rounded" class="mt4px" />

--- a/packages/devtools-kit/src/core/component/state/format.ts
+++ b/packages/devtools-kit/src/core/component/state/format.ts
@@ -1,3 +1,4 @@
+import { InspectorCustomState, InspectorState } from '../types'
 import { INFINITY, NAN, NEGATIVE_INFINITY, UNDEFINED, rawTypeRE, specialTypeRE } from './constants'
 import { isPlainObject } from './is'
 import { escape, internalStateTokenToString } from './util'
@@ -81,4 +82,20 @@ export function formatInspectorStateValue(value, quotes = false) {
       .replace(/\n/g, '<span>\\n</span>')
   }
   return value
+}
+
+export function getRawValue(value: InspectorState['value']) {
+  const isCustom = getInspectorStateValueType(value) === 'custom'
+  let inherit = {}
+  if (isCustom) {
+    const data = value as InspectorCustomState
+    inherit = data._custom?.fields || {}
+    value = data._custom?.value as string
+  }
+  // @ts-expect-error @TODO: type
+  if (value && value._isArray)
+    // @ts-expect-error @TODO: type
+    value = value.items
+
+  return { value, inherit }
 }

--- a/packages/devtools-kit/src/shared/util.ts
+++ b/packages/devtools-kit/src/shared/util.ts
@@ -1,4 +1,4 @@
-import { formatInspectorStateValue, getInspectorStateValueType } from '../core/component/state/format'
+import { formatInspectorStateValue, getInspectorStateValueType, getRawValue } from '../core/component/state/format'
 import { stringifyReplacer } from '../core/component/state/replacer'
 import { reviver } from '../core/component/state/reviver'
 import { parseCircularAutoChunks, stringifyCircularAutoChunks } from './transfer'
@@ -19,4 +19,5 @@ export function parse(data: string, revive = false) {
 export {
   formatInspectorStateValue,
   getInspectorStateValueType,
+  getRawValue,
 }


### PR DESCRIPTION
fix: #127

- Abstract function getRawValue.
- Use deserialized value on editing custom objects.


https://github.com/vuejs/devtools-next/assets/22590005/de5ac8eb-a085-432c-9ef2-899027b71f81

