### PR TITLE
fix(vite): respect `clientHost` option for overlay asset URLs

### DIFF
--- a/packages/vite/src/overlay.js
+++ b/packages/vite/src/overlay.js
@@ -3,7 +3,7 @@ import { Bridge, prepareInjection, setDevToolsClientUrl } from '@vue/devtools-co
 import { BROADCAST_CHANNEL_NAME } from '@vue/devtools-shared'
 import { addCustomTab, devtools } from '@vue/devtools-kit'
 
-const overlayDir = `${vueDevToolsOptions.base || '/'}@id/virtual:vue-devtools-path:overlay`
+const overlayDir = `${vueDevToolsOptions.clientHost || ''}${vueDevToolsOptions.base || '/'}@id/virtual:vue-devtools-path:overlay`
 const body = document.getElementsByTagName('body')[0]
 const head = document.getElementsByTagName('head')[0]
 


### PR DESCRIPTION
see: #123 

Currently the assets for the overlay are loaded from just a path, if the `clientHost` config is set it should load the assets from this URL