### PR TITLE
docs: fix `vite-plugin-inspect` repo url

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -58,7 +58,7 @@ Settings tab provides some options to customize the DevTools.
 
 ## Inspect
 
-Inspect expose the [vite-plugin-inspect](https://github.com/webfansplz/vite-plugin-inspect) integration, allowing you to inspect transformation steps of Vite.
+Inspect expose the [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect) integration, allowing you to inspect transformation steps of Vite.
 
 ![inspect](/features/inspect.svg)
 


### PR DESCRIPTION
## description

This PR is to update `vite-plugin-inspect` URL in the docs.

The package of the latest version `v0.8.1` is in use in this repo. But the original URL links to a forked repo with the previous version.