### PR TITLE
fix(client): deserialize value on drafting new prop

### DIFF
--- a/packages/client/src/components/inspector/InspectorStateField.vue
+++ b/packages/client/src/components/inspector/InspectorStateField.vue
@@ -156,8 +156,8 @@ function submitDrafting() {
     nodeId,
     state: {
       newKey: draftingNewProp.value.key,
-      type: typeof draftingNewProp.value.value,
-      value: draftingNewProp.value.value,
+      type: typeof toSubmit(draftingNewProp.value.value),
+      value: toSubmit(draftingNewProp.value.value),
     },
   } satisfies InspectorStateEditorPayload)
   resetDrafting()


### PR DESCRIPTION
The value of the drafted new prop is submitted as a string, deserialize the string value by `toSubmit`

Before:
<img width="323" alt="Screenshot 2024-02-04 at 11 24 08" src="https://github.com/vuejs/devtools-next/assets/22590005/78836ef5-970b-48ff-a906-6507f5f46abc">


After:
<img width="298" alt="Screenshot 2024-02-04 at 11 22 54" src="https://github.com/vuejs/devtools-next/assets/22590005/49c38cf8-3c37-41b5-bf94-2641debe0dba">
