### PR TITLE
chore: improve sidebar style

### DIFF
--- a/packages/client/src/components/common/SideNav.vue
+++ b/packages/client/src/components/common/SideNav.vue
@@ -53,10 +53,10 @@ onClickOutside(
           ref="buttonDocking"
           flex="~ items-center justify-center gap-2"
           hover="bg-active"
-          text-secondary relative h-10 select-none p2
+          text-secondary relative h-10 w-full select-none p2
           exact-active-class="!text-primary bg-active"
           :class="[
-            sidebarExpanded ? 'w-full rounded pl2.5' : 'w-10 rounded-xl',
+            sidebarExpanded ? 'rounded pl2.5' : 'rounded-xl',
           ]"
         >
           <div i-logos-vue h-6 w-6 />

--- a/packages/client/src/components/common/SideNav.vue
+++ b/packages/client/src/components/common/SideNav.vue
@@ -75,8 +75,7 @@ onClickOutside(
     </div>
 
     <div
-      flex="~ auto col gap-0.5 items-center" w-full p1 class="no-scrollbar"
-      :class="sidebarExpanded ? '' : 'of-x-hidden of-y-auto'"
+      flex="~ auto col gap-0.5 items-center" w-full of-x-hidden of-y-auto p1 class="no-scrollbar"
     >
       <template v-for="[name, tabs], idx of displayedTabs" :key="name">
         <!-- if is not the first nonempty list, render the top divider -->


### PR DESCRIPTION
- [x] center the logo in the minimized sidebar
- [x] in the expanded sidebar, menu item overlapping with the logo


<img width="87" alt="image" src="https://github.com/vuejs/devtools-next/assets/3993028/2b6c2c68-7ad3-4f95-9cbf-94099468ae93">

<img width="297" alt="image" src="https://github.com/vuejs/devtools-next/assets/3993028/ff59e384-ca2a-4760-b5fc-8691ec6c4608">
