### PR TITLE
feat(standalone): add default host/port for connect function

### DIFF
--- a/docs/guide/standalone.md
+++ b/docs/guide/standalone.md
@@ -105,7 +105,7 @@ And connect to host:
 
 ```ts
 if (process.env.NODE_ENV === 'development')
-  devtools.connect(/* host, port */)
+  devtools.connect(/* host (the default is "http://localhost"), port (the default is 8090) */)
 ```
 
 :::tip Important

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -1,7 +1,7 @@
 import { target } from '@vue/devtools-shared'
 import { devtools } from '../../devtools-kit/src/index'
 
-export async function connect(host: string, port: number) {
+export async function connect(host = 'http://localhost', port = 8098) {
   devtools.init()
   target.__VUE_DEVTOOLS_HOST__ = host
   target.__VUE_DEVTOOLS_PORT__ = port

--- a/packages/playground/termui/src/main.ts
+++ b/packages/playground/termui/src/main.ts
@@ -8,7 +8,7 @@ globalThis.document = {
   getElementById: () => {},
 } as any
 
-devtools.connect('http://localhost', 8098)
+devtools.connect()
 
 const app = createApp(App)
 app.mount()


### PR DESCRIPTION
feat(standalone) Add defaults host/port for func: connect 