### PR TITLE
refactor: migrate vite client bundle files directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ packages/browser-extension/overlay/**/*
 packages/browser-extension/client/**/*
 packages/electron/client/**/*
 packages/vite/src/overlay/**/*
+packages/vite/client/**/*
 docs/.vitepress/cache/
 
 # for scripts

--- a/packages/client/scripts/pre-build.ts
+++ b/packages/client/scripts/pre-build.ts
@@ -5,11 +5,12 @@ import fse from 'fs-extra'
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 async function run() {
-  ;['../../browser-extension/client', '../../electron/client', '../../vite/dist/client'].forEach((dir) => {
+  ;['../../browser-extension/client', '../../electron/client', '../../vite/client'].forEach((dir) => {
     const absoluteDir = resolve(__dirname, dir)
     if (fse.existsSync(absoluteDir))
       fse.removeSync(absoluteDir)
   })
+  console.log('🎉 Pre-build: removed client bundles successfully.\n')
 }
 
 await run()

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(mergeConfig(baseConfig, {
         // copy
         const clientFile = resolve(__dirname, './dist')
 
-        ;['../browser-extension/client', '../electron/client', '../vite/dist/client'].forEach((dir) => {
+        ;['../browser-extension/client', '../electron/client', '../vite/client'].forEach((dir) => {
           fse.copySync(clientFile, resolve(__dirname, dir))
         })
       },

--- a/packages/client/vite.lib.config.ts
+++ b/packages/client/vite.lib.config.ts
@@ -43,8 +43,6 @@ export default defineConfig(mergeConfig(baseConfig, {
         // copy
         const clientFile = resolve(__dirname, './dist')
         ;['../browser-extension/client', '../electron/client'].forEach((dir) => {
-          // NOTE: remember the order of `build:lib` and `build`,
-          // if change the order, rmSync must set in `build` stage
           fse.copySync(clientFile, resolve(__dirname, dir))
         })
       },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,6 +35,7 @@
     "*.d.ts",
     "./src/overlay.js",
     "./src/overlay/**",
+    "client",
     "dist",
     "overlay"
   ],

--- a/packages/vite/src/dir.ts
+++ b/packages/vite/src/dir.ts
@@ -5,4 +5,4 @@ export const DIR_DIST = typeof __dirname !== 'undefined'
   ? __dirname
   : dirname(fileURLToPath(import.meta.url))
 
-export const DIR_CLIENT = resolve(DIR_DIST, '../dist/client')
+export const DIR_CLIENT = resolve(DIR_DIST, '../client')


### PR DESCRIPTION
Migrate to the top-level client directory to avoid build order restrictions.