### PR TITLE
fix(client): revert getting pinia state on update

### DIFF
--- a/packages/client/src/pages/pinia.vue
+++ b/packages/client/src/pages/pinia.vue
@@ -23,12 +23,6 @@ const getInspectorState = defineDevToolsAction('devtools:inspector-state', (devt
   return devtools.api.getInspectorState(payload)
 })
 
-const onComponentUpdated = defineDevToolsListener((devtools, callback) => {
-  devtools.api.on.componentUpdated(() => {
-    callback()
-  })
-})
-
 const onInspectorTreeUpdated = defineDevToolsListener<string>((devtools, callback) => {
   devtools.api.on.sendInspectorTree((payload) => {
     callback(payload)
@@ -59,19 +53,13 @@ watch(selected, () => {
 createCollapseContext('inspector-state')
 
 onDevToolsClientConnected(() => {
-  const getPiniaInspectorTree = () => {
-    getInspectorTree({ inspectorId, filter: '' }).then((_data) => {
-      const data = parse(_data)
-      tree.value = data
-      if (!selected.value && data.length)
-        selected.value = data[0].id
+  getInspectorTree({ inspectorId, filter: '' }).then((_data) => {
+    const data = parse(_data)
+    tree.value = data
+    if (!selected.value && data.length) {
+      selected.value = data[0].id
       getPiniaState(data[0].id)
-    })
-  }
-  getPiniaInspectorTree()
-
-  onComponentUpdated(() => {
-    getPiniaInspectorTree()
+    }
   })
 
   onInspectorTreeUpdated((_data) => {


### PR DESCRIPTION
Fix: #263

Reverting modification: https://github.com/vuejs/devtools-next/pull/244/files#diff-42f4e2af39f7cbaa4712c9e872faf3068c7327869f5da043054fa298e60a2fc8R37-R53

Refetching the state on component updating will unexpectedly update the current state.

FYI: #244 aimed to resolve dynamic pinia module registration, but it was resolved by #247.
So reverting this logic does not affect dynamic module registration.