### PR TITLE
fix(client): route param regex overflows container

### DIFF
--- a/packages/client/src/components/inspector/InspectorTree.vue
+++ b/packages/client/src/components/inspector/InspectorTree.vue
@@ -30,7 +30,7 @@ function select(id: string) {
     page-mode
   >
     <div class="selectable-item" :class="{ active: modelValue === item.id }" @click="select(item.id)">
-      <span>
+      <span class="selectable-item-label">
         {{ item.label }}
       </span>
       <InspectorNodeTag v-for="(childItem, index) in item.tags" :key="index" :tag="childItem" />

--- a/packages/client/uno.config.ts
+++ b/packages/client/uno.config.ts
@@ -72,6 +72,7 @@ export default defineConfig(mergeConfigs([unoConfig, {
     'panel-grids-center': 'panel-grids flex flex-col h-full gap-2 items-center justify-center',
 
     'selectable-item': 'flex items-center px-2 py-1 rounded cursor-pointer hover:bg-primary-200 dark:(hover:bg-gray-800) @active:(text-white bg-primary-600 hover:(text-white bg-primary-600))',
+    'selectable-item-label': 'text-truncate',
 
     // component state
     'state-key': 'text-purple-700 dark:text-purple-300',


### PR DESCRIPTION
Truncate the path to account for custom regex in the route params. Fixes #235.

To illustrate, you can define a route with custom regex in the param as seen here for a UUID:

```typescript
{
  path: '/hello/:id([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})',
  component: () => import('./pages/Hello.vue'),
  name: 'hello',
}
```

## Before

<img width="1054" alt="route path overflowing container" src="https://github.com/vuejs/devtools-next/assets/2229946/ef57ba7c-0e98-4a39-9bdb-ba34dabc6d05">

## After

![route path truncated](https://github.com/vuejs/devtools-next/assets/2229946/a09a0c34-8e27-4179-8510-66fce729621b)
