### PR TITLE
feat(vite): support wasm asset file type

### DIFF
--- a/packages/client/src/components/assets/AssetListItem.vue
+++ b/packages/client/src/components/assets/AssetListItem.vue
@@ -32,6 +32,8 @@ const icon = computed(() => {
     return 'i-carbon-document'
   if (props.item.type === 'json')
     return 'i-carbon-json'
+  if (props.item.type === 'wasm')
+    return 'i-vscode-icons-file-type-wasm'
   return 'i-carbon-document-blank'
 })
 </script>

--- a/packages/client/src/components/assets/AssetPreview.vue
+++ b/packages/client/src/components/assets/AssetPreview.vue
@@ -29,6 +29,7 @@ defineProps<{
       <div v-if="!detail" i-carbon-volume-up text-3xl op20 />
       <audio v-else :src="asset.publicPath" controls />
     </div>
+    <div v-else-if="asset.type === 'wasm'" i-vscode-icons-file-type-wasm text-3xl />
     <div v-else i-carbon-help text-3xl op20 />
   </div>
 </template>

--- a/packages/core/src/vite-bridge/module-types.ts
+++ b/packages/core/src/vite-bridge/module-types.ts
@@ -1,5 +1,5 @@
 // assets
-export type AssetType = 'image' | 'font' | 'video' | 'audio' | 'text' | 'json' | 'other'
+export type AssetType = 'image' | 'font' | 'video' | 'audio' | 'text' | 'json' | 'wasm' | 'other'
 export interface AssetInfo {
   path: string
   type: AssetType

--- a/packages/vite/src/modules/assets.ts
+++ b/packages/vite/src/modules/assets.ts
@@ -50,6 +50,8 @@ function guessType(path: string): AssetType {
     return 'font'
   if (/\.(json[5c]?|te?xt|[mc]?[jt]sx?|md[cx]?|markdown|ya?ml|toml)/i.test(path))
     return 'text'
+  if (/\.wasm/i.test(path))
+    return 'wasm'
   return 'other'
 }
 
@@ -73,6 +75,8 @@ export function setupAssetsModule(options: { rpc: ViteInspectAPI['rpc'], server:
       '**/*.(woff2?|eot|ttf|otf|ttc|pfa|pfb|pfm|afm)',
       // text
       '**/*.(json|json5|jsonc|txt|text|tsx|jsx|md|mdx|mdc|markdown|yaml|yml|toml)',
+      // wasm
+      '**/*.wasm',
     ], {
       cwd: dir,
       onlyFiles: true,
@@ -100,6 +104,7 @@ export function setupAssetsModule(options: { rpc: ViteInspectAPI['rpc'], server:
         mtime: stat.mtimeMs,
       }
     }))
+    console.log('===>', cache)
     return cache
   }
 

--- a/packages/vite/src/modules/assets.ts
+++ b/packages/vite/src/modules/assets.ts
@@ -104,7 +104,6 @@ export function setupAssetsModule(options: { rpc: ViteInspectAPI['rpc'], server:
         mtime: stat.mtimeMs,
       }
     }))
-    console.log('===>', cache)
     return cache
   }
 


### PR DESCRIPTION
## desscription

This PR is to add scanning `wasm` files in the `assets` tab.

Because there are no icons related to the wasm files in the `carbon` presets, so I use the `vscode-icons`