### PR TITLE
refactor(applet): use `vite-plugin-dts` to generate dts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "turbo build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint:packages": "pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared}' exec publint && pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared}' exec attw --pack",
+    "lint:packages": "pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared,applet}' exec publint && pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared,applet}' exec attw --pack",
     "prepublishOnly": "npm run build",
     "release": "bumpp -r && nr build && pnpm -r publish --access public",
     "release:beta": "bumpp -r && nr build && pnpm -r publish --access public --tag beta",

--- a/packages/applet/index.d.ts
+++ b/packages/applet/index.d.ts
@@ -1,1 +1,0 @@
-export * from './src/index'

--- a/packages/applet/package.json
+++ b/packages/applet/package.json
@@ -13,7 +13,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [
@@ -45,7 +44,6 @@
     "unplugin-vue": "^5.0.5",
     "vite-plugin-dts": "^3.8.1",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0",
-    "vue-tsc": "^1.8.27"
+    "vue-router": "^4.3.0"
   }
 }

--- a/packages/applet/package.json
+++ b/packages/applet/package.json
@@ -13,14 +13,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*",
-        "./*"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],

--- a/packages/applet/package.json
+++ b/packages/applet/package.json
@@ -13,15 +13,21 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
-    "**.d.ts",
     "dist"
   ],
   "scripts": {
-    "build": "vite build && pnpm types",
-    "prepare:type": "pnpm types",
-    "stub": "vite build --watch",
-    "types": "vue-tsc --declaration --emitDeclarationOnly -p ./tsconfig.json"
+    "build": "vite build",
+    "stub": "vite build --watch"
   },
   "peerDependencies": {
     "vue": "^3.0.0"
@@ -37,6 +43,7 @@
   },
   "devDependencies": {
     "unplugin-vue": "^5.0.5",
+    "vite-plugin-dts": "^3.8.1",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0",
     "vue-tsc": "^1.8.27"

--- a/packages/applet/tsconfig.json
+++ b/packages/applet/tsconfig.json
@@ -13,5 +13,5 @@
     "outDir": "./dist",
     "skipLibCheck": true
   },
-  "include": ["**/*.vue", "**/*.d.ts", "**/*.ts"]
+  "include": ["src/**/*.vue", "src/**/*.d.ts", "src/**/*.ts"]
 }

--- a/packages/applet/vite.config.ts
+++ b/packages/applet/vite.config.ts
@@ -1,7 +1,7 @@
-import { join, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import Vue from '@vitejs/plugin-vue'
 import Unocss from 'unocss/vite'
-import fse from 'fs-extra'
+import Dts from 'vite-plugin-dts'
 
 const argv = process.argv.slice(2)
 const enableWatch = argv.includes('--watch')
@@ -15,17 +15,7 @@ export default {
   plugins: [
     Unocss(),
     Vue(),
-    {
-      name: 'move-dts',
-      apply: 'build',
-      enforce: 'post',
-      closeBundle() {
-        // copy
-        const targetDir = resolve(__dirname, './dist')
-
-        fse.copySync('./index.d.ts', join(targetDir, './index.d.ts'))
-      },
-    },
+    Dts(),
   ],
   build: {
     emptyOutDir: !enableWatch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       unplugin-vue:
         specifier: ^5.0.5
         version: 5.0.5(@types/node@20.12.5)(vue@3.4.21)
+      vite-plugin-dts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/node@20.12.5)(rollup@3.28.1)(typescript@5.4.4)(vite@5.2.8)
       vue:
         specifier: ^3.4.21
         version: 3.4.21(typescript@5.4.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,9 +183,6 @@ importers:
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
-      vue-tsc:
-        specifier: ^1.8.27
-        version: 1.8.27(typescript@5.4.4)
 
   packages/browser-extension:
     dependencies:


### PR DESCRIPTION
## description

This PR is to use `vite-plugin-dts` to emit dts files under the `package/applet` and update exports fields related to type declarations in the `package.json`.