### PR TITLE
feat: in inspecting mode, when a component is clicked, scroll the corresponding node into view

### DIFF
--- a/packages/client/src/components/components/ComponentTreeNode.vue
+++ b/packages/client/src/components/components/ComponentTreeNode.vue
@@ -20,10 +20,15 @@ const { isExpanded, toggleCollapse } = useCollapse('component-tree', props.data.
 const { isSelected, toggleSelected } = useSelectWithContext('component-tree', props.data.id, (id) => {
   emit('select', id)
 })
+
+const nodeEl = ref<HTMLDivElement>()
+
+useScrollSelectedIntoView(nodeEl, isSelected)
 </script>
 
 <template>
   <div
+    ref="nodeEl"
     class="group selectable-item"
     :style="{ paddingLeft: `${depth * 15 + 4}px` }"
     :class="{ active: isSelected }"

--- a/packages/client/src/composables/select.ts
+++ b/packages/client/src/composables/select.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue'
 import { ref } from 'vue'
+import { promiseTimeout } from '@vueuse/core'
 
 export function createSelectContext(id: string) {
   const selected = ref<string>('')
@@ -43,4 +44,25 @@ export function useSelectWithContext(groupId: string, id: string, onSelect?: (id
     isSelected,
     toggleSelected,
   }
+}
+
+export function useScrollSelectedIntoView(nodeEl: Ref<HTMLDivElement | undefined>, isSelected: ComputedRef<boolean>) {
+  whenever(isSelected, async () => {
+    await promiseTimeout(100)
+
+    const parentEl = nodeEl.value?.parentElement
+    if (!parentEl || !nodeEl.value)
+      return
+
+    const bounds = nodeEl.value.getBoundingClientRect()
+    const parentBounds = parentEl.getBoundingClientRect()
+
+    const isNodeVisible = bounds.top >= parentBounds.top && bounds.bottom <= parentBounds.bottom
+    if (!isNodeVisible) {
+      parentEl?.scrollBy({
+        top: bounds.top - parentBounds.top - parentBounds.height / 2 + bounds.height / 2,
+        behavior: 'smooth',
+      })
+    }
+  })
 }


### PR DESCRIPTION
Currently when inspecting a component, and the `ComponentTreeNode` is not showing in scroll container, it won't automatically scroll into view: 

![录屏2024-04-10 14 14 19](https://github.com/vuejs/devtools-next/assets/51878637/37a40bed-f700-4496-8c29-86200b7ad7c6)

This PR fixes it:

![录屏2024-04-10 14 17 09](https://github.com/vuejs/devtools-next/assets/51878637/4518fe35-2313-4731-a898-904bff460ca8)

