### PR TITLE
fix(vite): cjs compatible

### DIFF
--- a/packages/vite/build.config.ts
+++ b/packages/vite/build.config.ts
@@ -1,0 +1,19 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    'src/vite',
+  ],
+  clean: true,
+  declaration: true,
+  externals: [
+    'vite',
+    'vite-plugin-inspect',
+    'vite-plugin-vue-inspector',
+    'execa',
+  ],
+  rollup: {
+    emitCJS: true,
+    inlineDependencies: true,
+  },
+})

--- a/packages/vite/esbuild-shims/cjs-shim.ts
+++ b/packages/vite/esbuild-shims/cjs-shim.ts
@@ -1,7 +1,3 @@
 import { createRequire } from 'node:module'
-import path from 'node:path'
-import url from 'node:url'
 
 globalThis.require = createRequire(import.meta.url)
-globalThis.__filename = url.fileURLToPath(import.meta.url)
-globalThis.__dirname = path.dirname(__filename)

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -43,7 +43,7 @@
     "node": ">=v14.21.3"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "unbuild",
     "stub": "tsup --watch"
   },
   "peerDependencies": {


### PR DESCRIPTION
Looks like `tsup` shim with our custom esbuild shim has come into conflict in cjs mode.

Revert to use `unbuild` for build, `tsup` for dev.

closes #331 , have tested.