### PR TITLE
feat(vite): show asset importers

### DIFF
--- a/packages/client/src/components/assets/AssetDetails.vue
+++ b/packages/client/src/components/assets/AssetDetails.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
-import type { AssetInfo, CodeSnippet, ImageMeta } from '@vue/devtools-core'
+import type { AssetImporter, AssetInfo, CodeSnippet, ImageMeta } from '@vue/devtools-core'
 import { callViteServerAction, useDevToolsState } from '@vue/devtools-core'
 import { VueButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
 import { openInEditor } from '../../composables/open-in-editor'
@@ -15,6 +15,9 @@ const state = useDevToolsState()
 const getImageMeta = callViteServerAction<ImageMeta>('assets:get-image-meta')
 const getTextAssetContent = callViteServerAction<string>('assets:get-text-asset-content')
 const asset = useVModel(props, 'modelValue', emit, { passive: true })
+
+const getAssetImporters = callViteServerAction<AssetImporter[]>('assets:get-asset-importers')
+const importers = computedAsync(() => getAssetImporters(asset.value.publicPath), [])
 
 const _vueInspectorDetected = computed(() => vueInspectorDetected.value)
 const imageMeta = computedAsync(() => {
@@ -211,6 +214,30 @@ const supportsPreview = computed(() => {
             Last modified
           </td>
           <td>{{ new Date(asset.mtime).toLocaleString() }} <span op70>({{ timeAgo }})</span></td>
+        </tr>
+        <tr>
+          <td w-30 ws-nowrap pr5 text-right align-top op50>
+            Importers
+          </td>
+          <td>
+            <template v-if="importers.length > 0">
+              <div v-for="importer in importers" :key="importer.url" flex="~ gap-1" w-full items-center>
+                <FilepathItem :filepath="importer.id || importer.url" text-left />
+                <VueIcon
+                  v-if="state.vitePluginDetected.value && _vueInspectorDetected && importer.id"
+                  v-tooltip="'Open in Editor'"
+                  title="Open in Editor"
+                  icon="i-carbon-launch"
+                  action flex-none
+                  :border="false"
+                  @click="openInEditor(importer.id!)"
+                />
+              </div>
+            </template>
+            <template v-else>
+              None
+            </template>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/packages/core/src/vite-bridge/module-types.ts
+++ b/packages/core/src/vite-bridge/module-types.ts
@@ -1,3 +1,5 @@
+import type { ModuleNode } from 'vite'
+
 // assets
 export type AssetType = 'image' | 'font' | 'video' | 'audio' | 'text' | 'json' | 'wasm' | 'other'
 export interface AssetInfo {
@@ -15,6 +17,8 @@ export interface ImageMeta {
   type?: string
   mimeType?: string
 }
+
+export type AssetImporter = Pick<ModuleNode, 'url' | 'id'>
 
 export interface AssetEntry {
   path: string

--- a/packages/playground/basic/src/pages/Hey.vue
+++ b/packages/playground/basic/src/pages/Hey.vue
@@ -7,6 +7,7 @@ const counterStore = useCounterStore()
 
 <template>
   <div class="container">
+    <img src="/vite.svg">
     Hey: {{ route.params.id }}
     Counter: {{ counterStore.count }}
   </div>

--- a/packages/playground/basic/src/pages/Home.vue
+++ b/packages/playground/basic/src/pages/Home.vue
@@ -8,6 +8,7 @@ const visible = ref(false)
   <div class="m-auto mt-3 h-80 w-120 flex flex-col items-center justify-center rounded bg-[#363636]">
     Home
     <Foo v-if="visible" />
+    <img src="/vite.svg">
     <button class="w-30 cursor-pointer" @click="visible = !visible">
       Toggle Foo
     </button>


### PR DESCRIPTION
## description

This PR is related to #208.

It defines a new Vite server action `assets:get-asset-importers` to help to get the targeted asset's importers depending on Vite's module graph in the `AssetDetails`.