### PR TITLE
fix(applet): incorrect rendering on overflowed TreeViewer

### DIFF
--- a/packages/applet/src/components/tree/TreeViewer.vue
+++ b/packages/applet/src/components/tree/TreeViewer.vue
@@ -26,6 +26,9 @@ function select(id: string) {
   <div
     v-for="(item, index) in data"
     :key="index"
+    :class="{
+      'min-w-max': depth === 0,
+    }"
   >
     <div
       class="group flex cursor-pointer items-center rounded-1 hover:(bg-primary-300 dark:bg-gray-600)"


### PR DESCRIPTION
To avoid duplicate css / redundant width calculation, only adding this to the root TreeView is necessary.

Previous:

<img width="440" alt="image" src="https://github.com/vuejs/devtools-next/assets/49969959/3f847810-6ec0-40d8-ab83-7571671496d2">

After:

https://github.com/vuejs/devtools-next/assets/49969959/6d60091a-b53b-4b28-8907-942b7b13e608



