### PR TITLE
chore: use `vTooltip` instead of deprecated API

### DIFF
--- a/packages/applet/src/components/basic/NodeTag.vue
+++ b/packages/applet/src/components/basic/NodeTag.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { InspectorNodeTag } from '@vue/devtools-kit'
-import { VTooltip as vTooltip } from '@vue/devtools-ui'
+import { vTooltip } from '@vue/devtools-ui'
 import { toHex } from '~/utils'
 
 defineProps<{

--- a/packages/applet/src/components/state/StateFieldEditor.vue
+++ b/packages/applet/src/components/state/StateFieldEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, toRaw } from 'vue'
-import { VueButton, VueDropdown, VueDropdownButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueDropdown, VueDropdownButton, VueIcon, vTooltip } from '@vue/devtools-ui'
 import { getRaw } from '@vue/devtools-kit'
 import type { InspectorState, InspectorStateEditorPayload } from '@vue/devtools-kit'
 import type { ButtonProps } from '@vue/devtools-ui/dist/types/src/components/Button'

--- a/packages/applet/src/components/state/StateFieldInputEditor.vue
+++ b/packages/applet/src/components/state/StateFieldInputEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VueButton, VueIcon, VueInput, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueIcon, VueInput, vTooltip } from '@vue/devtools-ui'
 import { debounce } from 'perfect-debounce'
 import { customTypeEnums, toSubmit } from '@vue/devtools-kit'
 import { computed, ref, watch, watchEffect } from 'vue'

--- a/packages/applet/src/components/state/StateFieldViewer.vue
+++ b/packages/applet/src/components/state/StateFieldViewer.vue
@@ -4,7 +4,7 @@ import { formatInspectorStateValue, getInspectorStateValueType, getRaw, toEdit, 
 import { computed, ref, watch } from 'vue'
 import { editInspectorState } from '@vue/devtools-core'
 import { isArray, isObject, sortByKey } from '@vue/devtools-shared'
-import { VueButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueIcon, vTooltip } from '@vue/devtools-ui'
 import ChildStateViewer from './ChildStateViewer.vue'
 import StateFieldEditor from './StateFieldEditor.vue'
 import StateFieldInputEditor from './StateFieldInputEditor.vue'

--- a/packages/applet/src/modules/components/index.vue
+++ b/packages/applet/src/modules/components/index.vue
@@ -14,7 +14,7 @@ import {
 } from '@vue/devtools-core'
 import { parse } from '@vue/devtools-kit'
 import { useElementSize, useToggle, watchDebounced } from '@vueuse/core'
-import { VueInput, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueInput, vTooltip } from '@vue/devtools-ui'
 import { sortByKey } from '@vue/devtools-shared'
 import { flatten, groupBy } from 'lodash-es'
 import ComponentRenderCode from './components/RenderCode.vue'

--- a/packages/client/src/components/assets/AssetDetails.vue
+++ b/packages/client/src/components/assets/AssetDetails.vue
@@ -2,7 +2,7 @@
 import { useTimeAgo } from '@vueuse/core'
 import type { AssetImporter, AssetInfo, CodeSnippet, ImageMeta } from '@vue/devtools-core'
 import { callViteServerAction, useDevToolsState } from '@vue/devtools-core'
-import { VueButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueIcon, vTooltip } from '@vue/devtools-ui'
 import { openInEditor } from '../../composables/open-in-editor'
 
 const props = defineProps<{

--- a/packages/client/src/components/assets/FilepathItem.vue
+++ b/packages/client/src/components/assets/FilepathItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VTooltip as vTooltip } from '@vue/devtools-ui'
+import { vTooltip } from '@vue/devtools-ui'
 
 const props = defineProps<{
   filepath: string

--- a/packages/client/src/components/common/SplitScreen.vue
+++ b/packages/client/src/components/common/SplitScreen.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VueButton, VueCard, VueDropdown, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueCard, VueDropdown, vTooltip } from '@vue/devtools-ui'
 
 function close() {
   devtoolsClientState.value.splitScreen.enabled = false

--- a/packages/client/src/components/inspector/InspectorDataField/Actions.vue
+++ b/packages/client/src/components/inspector/InspectorDataField/Actions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { toRaw } from 'vue'
-import { VueButton, VueDropdown, VueDropdownButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueDropdown, VueDropdownButton, VueIcon, vTooltip } from '@vue/devtools-ui'
 import { getRaw } from '@vue/devtools-kit'
 import type { InspectorState, InspectorStateEditorPayload } from '@vue/devtools-kit'
 import type { ButtonProps } from '@vue/devtools-ui/dist/types/src/components/Button'

--- a/packages/client/src/components/inspector/InspectorDataField/EditInput.vue
+++ b/packages/client/src/components/inspector/InspectorDataField/EditInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VueButton, VueIcon, VueInput, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueIcon, VueInput, vTooltip } from '@vue/devtools-ui'
 import { debounce } from 'perfect-debounce'
 import { customTypeEnums, toSubmit } from '@vue/devtools-kit'
 

--- a/packages/client/src/components/inspector/InspectorStateField.vue
+++ b/packages/client/src/components/inspector/InspectorStateField.vue
@@ -3,7 +3,7 @@ import type { InspectorCustomState, InspectorState, InspectorStateEditorPayload 
 import { isArray, isObject, sortByKey } from '@vue/devtools-shared'
 import { formatInspectorStateValue, getInspectorStateValueType, getRaw, toEdit, toSubmit } from '@vue/devtools-kit'
 import { editInspectorState } from '@vue/devtools-core'
-import { VueButton, VueIcon, VTooltip as vTooltip } from '@vue/devtools-ui'
+import { VueButton, VueIcon, vTooltip } from '@vue/devtools-ui'
 import Actions from './InspectorDataField/Actions.vue'
 import type { EditorAddNewPropType } from '~/composables/inspector'
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,12 +4,12 @@
 import '@unocss/reset/tailwind.css'
 import 'uno.css'
 
-import { VTooltip } from 'floating-vue'
+import { vTooltip } from 'floating-vue'
 
 export * from './components'
 export * from './composables'
 export * from './types'
 
 export {
-  VTooltip,
+  vTooltip,
 }


### PR DESCRIPTION
since https://github.com/Akryum/floating-vue/commit/abf094fe1009e43b4a2b9827cbb7f57fe66fe333

We should use `vTooltip` instead.