### PR TITLE
fix(devtools-kit): make `path` type optional in `InspectorState`

### DIFF
--- a/packages/devtools-kit/src/core/component/types/state.ts
+++ b/packages/devtools-kit/src/core/component/types/state.ts
@@ -17,7 +17,7 @@ export interface InspectorState {
   key: string
   value: string | number | boolean | null | Record<string, unknown> | InspectorCustomState | Array<unknown>
   type: string
-  path: string[]
+  path?: string[]
   stateType?: string
   stateTypeName?: string
   meta?: Record<string, boolean | string>


### PR DESCRIPTION
Fixed type error.
Reproduction:
```sh
pnpm turbo run build --filter=@vue/devtools-applet
```