### PR TITLE
docs: update playground link [ci skip]

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
       },
       {
         text: 'Playground',
-        link: 'https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/devtools',
+        link: 'https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/devtools-router-pinia',
       },
     ],
 


### PR DESCRIPTION
Once https://github.com/vuejs/create-vue/pull/523 is merged and the new template snapshot is created — `devtools` link will be updated to `devtools-router-pinia`. After merging this PR, playground will showcase Router & Pinia tabs.

### Update
Waiting for snapshot generation - https://github.com/vuejs/create-vue-templates/tree/069649e4613d3430f930935e2dbdb76a6a80ab2e