### PR TITLE
docs: update contributing URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please follow the documentation at [devtools-next.vuejs.org](https://devtools-ne
 
 ## Contribution
 
-Please make sure to read the [Contributing Guide](https://devtools-next.vuejs.org/guide/contributing) before making a pull request.
+Please make sure to read the [Contributing Guide](https://devtools-next.vuejs.org/help/contributing) before making a pull request.
 
 Thank you to all the people who already contributed to Vue DevTools!
 


### PR DESCRIPTION
As the documentation structure is changed, the URL is no longer valid.