### PR TITLE
docs: update vite plugin guide

### DIFF
--- a/docs/guide/vite-plugin.md
+++ b/docs/guide/vite-plugin.md
@@ -34,11 +34,11 @@ $ bun add -D vite-plugin-vue-devtools
 //  Configuration Vite
 
 import { defineConfig } from 'vite'
-import VueDevTools from 'vite-plugin-vue-devtools'
+import vueDevTools from 'vite-plugin-vue-devtools'
 
 export default defineConfig({
   plugins: [
-    VueDevTools(),
+    vueDevTools(),
   ],
 })
 ```


### PR DESCRIPTION
> The other plugins (vue, vueJsx and nightwatchPlugin) all follow the same convention to have a lowercase at the start, so let's do the same for vueDevTools

Reference: https://github.com/vuejs/create-vue/pull/524