### PR TITLE
fix: respect LAUNCH_EDITOR env rather than forcing 'code' as default

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -53,7 +53,7 @@ export interface VitePluginVueDevToolsOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm'
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | string
 
   /**
    * Customize openInEditor host

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -74,7 +74,7 @@ export interface VitePluginVueDevToolsOptions {
 const defaultOptions: VitePluginVueDevToolsOptions = {
   appendTo: '',
   componentInspector: true,
-  launchEditor: 'code',
+  launchEditor: process.env.LAUNCH_EDITOR ?? 'code',
 }
 
 function mergeOptions(options: VitePluginVueDevToolsOptions): VitePluginVueDevToolsOptions {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -53,7 +53,7 @@ export interface VitePluginVueDevToolsOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | string
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | String
 
   /**
    * Customize openInEditor host

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -53,7 +53,7 @@ export interface VitePluginVueDevToolsOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | String
+  launchEditor?: string
 
   /**
    * Customize openInEditor host

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -53,7 +53,7 @@ export interface VitePluginVueDevToolsOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: string
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | string
 
   /**
    * Customize openInEditor host


### PR DESCRIPTION
The user's LAUNCH_EDITOR env is being overwritten by the default `launchEditor` option. If no `launchEditor` option is specified it should default to the `LAUNCH_EDITOR` env value. Currently if `launchEditor` is not specified, the option is set to `"code"` and the user's LAUNCH_EDITOR setting is ignored.

This change will respect the user's LAUNCH_EDITOR env by default if no `launchEditor` option is specified.

This also allows an arbitrary string as a valid `launchEditor` type, [which is a valid option for `launch-editor`](https://github.com/yyx990803/launch-editor?tab=readme-ov-file#custom-editor-support) and is needed for custom launch scripts or when editors are installed in non-standard locations.

This fixes https://github.com/vuejs/devtools-next/issues/369