### PR TITLE
fix(overlay): hide panel when enable inspector

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -81,7 +81,24 @@ const vueInspector = ref()
 onDevToolsConnected(() => {
   devtools.api.getVueInspector().then((inspector) => {
     vueInspector.value = inspector
+
+    let previousPanelVisible = panelVisible.value
+
+    vueInspector.value.onEnabled = () => {
+      previousPanelVisible = panelVisible.value
+      togglePanelVisible(undefined, false)
+    }
+
+    vueInspector.value.onDisabled = () => {
+      togglePanelVisible(undefined, previousPanelVisible)
+    }
   })
+})
+
+addEventListener('keyup', (e) => {
+  if (e.key.toLowerCase() === 'escape' && vueInspector.value?.enabled) {
+    vueInspector.value?.disable()
+  }
 })
 
 const vueInspectorEnabled = computed(() => {

--- a/packages/overlay/src/composables/panel.ts
+++ b/packages/overlay/src/composables/panel.ts
@@ -15,7 +15,7 @@ export function usePanelVisible() {
     },
   })
 
-  const toggleVisible = (_: unknown, state?: boolean) => {
+  const toggleVisible = (_?: unknown, state?: boolean) => {
     visible.value = state ?? !visible.value
   }
 


### PR DESCRIPTION
closes #411

Hide the panel when enabling the inspector, and restore the state when disabling the inspector.

Use the `escape` shortcut to disable the inspector quickly.

https://github.com/vuejs/devtools-next/assets/49969959/08ee0fe0-3e3d-4ed1-8867-18c0d17eff31

