### PR TITLE
workflow: respect project pnpm version

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
       - name: Set node
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+
+      - name: Install pnpm
+        run: corepack enable pnpm
 
       - name: Setup
         run: npm i -g @antfu/ni

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
       - name: Set node
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+
+      - name: Install pnpm
+        uses: corepack enable pnpm
 
       - name: Setup ni
         run: npm i -g @antfu/ni


### PR DESCRIPTION
If the pnpm version is not the same as the project, the lockfiles of CI and local maybe differ, e.g [failed ci](https://github.com/vuejs/devtools-next/actions/runs/9283587663/job/25544254951)