### PR TITLE
chore:  in component module's state field viewer, allow select-text for string fields

### DIFF
--- a/packages/applet/src/components/state/StateFieldViewer.vue
+++ b/packages/applet/src/components/state/StateFieldViewer.vue
@@ -65,7 +65,8 @@ const normalizedDisplayedValue = computed(() => {
     const _type = (props.data.value as InspectorCustomState)?._custom?.type
     const _value = type.value === 'custom' && !_type ? `"${displayedValue.value}"` : (displayedValue.value === '' ? `""` : displayedValue.value)
     const normalizedType = type.value === 'custom' && _type === 'ref' ? getInspectorStateValueType(_value) : type.value
-    const result = `<span class="${normalizedType}-state-type flex whitespace-nowrap">${_value}</span>`
+    const selectText = type.value === 'string' ? 'select-text' : ''
+    const result = `<span class="${normalizedType}-state-type flex whitespace-nowrap ${selectText}">${_value}</span>`
 
     if (extraDisplayedValue)
       return `${result} <span class="text-gray-500">(${extraDisplayedValue})</span>`


### PR DESCRIPTION
As described in title, the component module's state field viewer now allows users to select string values. 

This enhancement facilitates operations such as copying a portion of the text value or using the browser's context menu with a simple right-click.

Before: 

![录屏2024-05-31 14 01 51](https://github.com/vuejs/devtools-next/assets/51878637/e1669fd2-47f9-49d5-91f7-4544a826c5be)

After: 

![录屏2024-05-31 13 56 53](https://github.com/vuejs/devtools-next/assets/51878637/9ca8efb7-ea9c-4c06-ba87-7cea6afb99c8)
