### PR TITLE
chore: expand component tree item by double clicking it

### DIFF
--- a/packages/applet/src/components/tree/TreeViewer.vue
+++ b/packages/applet/src/components/tree/TreeViewer.vue
@@ -39,6 +39,7 @@ function select(id: string) {
       :style=" { paddingLeft: `${15 * depth + 4}px` }"
       :class="{ 'bg-primary-600! active': selectedNodeId === item.id }"
       @click="select(item.id)"
+      @dblclick="toggleExpanded(item.id)"
     >
       <ToggleExpanded
         v-if="item?.children?.length"


### PR DESCRIPTION
This PR implements double-clicking anywhere on the line to toggle the expansion status of the component tree, just like the legacy devtools.

![录屏2024-05-31 14 58 33](https://github.com/vuejs/devtools-next/assets/51878637/208d4ffc-8374-48eb-88d9-56c085be30aa)
