### PR TITLE
feat(vite): use vite.config.server.origin as devtools base path

### DIFF
--- a/packages/vite/src/overlay.js
+++ b/packages/vite/src/overlay.js
@@ -3,7 +3,7 @@ import { functions, setDevToolsClientUrl } from '@vue/devtools-core'
 import { addCustomTab, createRpcServer, devtools, setDevToolsEnv, setOpenInEditorBaseUrl, toggleComponentInspectorEnabled } from '@vue/devtools-kit'
 
 function normalizeUrl(url) {
-  return new URL(`${vueDevToolsOptions.base || '/'}${url}`, import.meta.url).toString()
+  return new URL(`${vueDevToolsOptions.base || ''}/${url}`, import.meta.url).toString()
 }
 
 const overlayDir = normalizeUrl(`@id/virtual:vue-devtools-path:overlay`)


### PR DESCRIPTION
closes #436 

Some frameworks use Vite as their dev server but with different hosts, e.g. WXT uses Vite but the runtime path (aka the vite. config. base) is `chrome-extension://<extension-id>` instead of `http://localhost:<vite-port>/`

 Using `vite.config.server.origin` is more advantageous as it ensures all injected devtools resources are hosted by Vite.

Works on WXT & Laravel

`WXT` screenshot:


https://github.com/vuejs/devtools-next/assets/49969959/73e53f13-3990-4548-b1cc-5076ad708194

`Laravel` screenshot:



https://github.com/vuejs/devtools-next/assets/49969959/5c3ae13d-ae40-4e0a-846c-4d06b10abfbf


