### PR TITLE
fix(vite): normalize separate window url when apply `base` option

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'node:url'
+import { URL, fileURLToPath, format } from 'node:url'
 import path from 'node:path'
 import { normalizePath } from 'vite'
 import type { PluginOption, ResolvedConfig, ViteDevServer } from 'vite'
@@ -111,8 +111,13 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
       const urls = server.resolvedUrls!
       const keys = normalizeComboKeyPrint('option-shift-d')
       _printUrls()
-      for (const url of urls.local)
-        console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Open ${colorUrl(`${url}__devtools__/`)} as a separate window`)}`)
+      for (const url of urls.local) {
+        const urlString = `${url}/__devtools__/`
+        const parsedUrl = new URL(urlString)
+        parsedUrl.pathname = path.normalize(parsedUrl.pathname).replace(/\\/g, '/')
+        const devtoolsUrl = format(parsedUrl)
+        console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Open ${colorUrl(`${devtoolsUrl}`)} as a separate window`)}`)
+      }
       console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(keys)} in App to toggle the Vue DevTools`)}\n`)
     }
   }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,4 +1,4 @@
-import { URL, fileURLToPath, format } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { normalizePath } from 'vite'
 import type { PluginOption, ResolvedConfig, ViteDevServer } from 'vite'
@@ -112,10 +112,7 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
       const keys = normalizeComboKeyPrint('option-shift-d')
       _printUrls()
       for (const url of urls.local) {
-        const urlString = `${url}/__devtools__/`
-        const parsedUrl = new URL(urlString)
-        parsedUrl.pathname = path.normalize(parsedUrl.pathname).replace(/\\/g, '/')
-        const devtoolsUrl = format(parsedUrl)
+        const devtoolsUrl = url.endsWith('/') ? `${url}__devtools__/` : `${url}/__devtools__/`
         console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Open ${colorUrl(`${devtoolsUrl}`)} as a separate window`)}`)
       }
       console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(keys)} in App to toggle the Vue DevTools`)}\n`)


### PR DESCRIPTION
fixes #441 

<img width="1405" alt="image" src="https://github.com/vuejs/devtools-next/assets/9697295/4ca8fd77-4d30-4cc8-92ff-6c83709292ed">
