### PR TITLE
fix(client): sync state between separate window with floating panel

### DIFF
--- a/packages/client/src/pages/settings.vue
+++ b/packages/client/src/pages/settings.vue
@@ -10,7 +10,19 @@ import { VueButton, VueCard, VueCheckbox, VueConfirm, VueDarkToggle, VueSelect, 
 
 const { categorizedTabs: categories } = useAllTabs()
 
-const { scale, interactionCloseOnOutsideClick, showPanel, minimizePanelInteractive, expandSidebar, scrollableSidebar } = toRefs(devtoolsClientState.value)
+const {
+  scale,
+  interactionCloseOnOutsideClick,
+  showPanel,
+  minimizePanelInteractive,
+  expandSidebar,
+  scrollableSidebar,
+} = toRefs(toReactive(devtoolsClientState))
+
+watchEffect(() => {
+  console.log('devtools', devtoolsClientState.value.showPanel)
+  console.log('aaa', showPanel)
+})
 
 // #region settings
 const scaleOptions = [

--- a/packages/client/src/pages/settings.vue
+++ b/packages/client/src/pages/settings.vue
@@ -19,11 +19,6 @@ const {
   scrollableSidebar,
 } = toRefs(toReactive(devtoolsClientState))
 
-watchEffect(() => {
-  console.log('devtools', devtoolsClientState.value.showPanel)
-  console.log('aaa', showPanel)
-})
-
 // #region settings
 const scaleOptions = [
   ['Tiny', 12 / 15],

--- a/packages/client/src/pages/settings.vue
+++ b/packages/client/src/pages/settings.vue
@@ -10,14 +10,7 @@ import { VueButton, VueCard, VueCheckbox, VueConfirm, VueDarkToggle, VueSelect, 
 
 const { categorizedTabs: categories } = useAllTabs()
 
-const {
-  scale,
-  interactionCloseOnOutsideClick,
-  showPanel,
-  minimizePanelInteractive,
-  expandSidebar,
-  scrollableSidebar,
-} = toRefs(toReactive(devtoolsClientState))
+const { scale, interactionCloseOnOutsideClick, showPanel, minimizePanelInteractive, expandSidebar, scrollableSidebar } = toRefs(toReactive(devtoolsClientState))
 
 // #region settings
 const scaleOptions = [


### PR DESCRIPTION
should close #458, need test by @sxcooler, test on my local works properly.

Reproduction step:
1. open the page with the devtools floating panel
2. open a separate window
3. update settings on floating panel
4. go to the separate window, and storage is changed, but UI is not changed.