### PR TITLE
feat(browser-ext): update content_security_policy to support wasm

### DIFF
--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -33,7 +33,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },
   "description": "DevTools browser extension for Vue.js",
   "devtools_page": "pages/devtools-background.html",

--- a/packages/firefox-extension/manifest.json
+++ b/packages/firefox-extension/manifest.json
@@ -34,7 +34,7 @@
       "run_at": "document_idle"
     }
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
   "description": "DevTools browser extension for Vue.js",
   "devtools_page": "devtools-background.html",
   "icons": {


### PR DESCRIPTION
firefox:

![firefox spec](https://github.com/vuejs/devtools-next/assets/49969959/dca32269-1506-4e0d-8555-f0bed2d30941)

chrome
![chrome spec](https://github.com/vuejs/devtools-next/assets/49969959/67cfae39-2315-4545-a85f-42af33592ab0)

They have indicated that using ‘wasm-unsafe-eval’ in the content policy to execute wasm is supported as the minimal permission.