### PR TITLE
fix: update shiki and relax version range

### DIFF
--- a/packages/applet/package.json
+++ b/packages/applet/package.json
@@ -30,7 +30,7 @@
     "@vue/devtools-ui": "workspace:^",
     "lodash-es": "^4.17.21",
     "perfect-debounce": "^1.0.0",
-    "shiki": "1.7.0",
+    "shiki": "^1.9.0",
     "splitpanes": "^3.1.5",
     "vue-virtual-scroller": "2.0.0-beta.8"
   },

--- a/packages/applet/src/composables/shiki.ts
+++ b/packages/applet/src/composables/shiki.ts
@@ -1,5 +1,5 @@
 import type { BuiltinLanguage, HighlighterCore } from 'shiki'
-import { getHighlighterCore } from 'shiki/core'
+import { createHighlighterCore } from 'shiki/core'
 import getWasm from 'shiki/wasm'
 import { shallowRef } from 'vue'
 
@@ -10,7 +10,7 @@ let promise: Promise<any> | null = null
 export function renderCodeHighlight(code: string, lang: BuiltinLanguage | 'text' = 'text') {
   if (!promise && !shiki.value) {
     // Only loading when needed
-    promise = getHighlighterCore({
+    promise = createHighlighterCore({
       themes: [
         import('shiki/themes/vitesse-dark.mjs'),
         import('shiki/themes/vitesse-light.mjs'),

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
     "colord": "^2.9.3",
     "fuse.js": "^7.0.0",
     "minimatch": "^9.0.4",
-    "shiki": "1.7.0",
+    "shiki": "^1.9.0",
     "splitpanes": "^3.1.5",
     "vis-network": "^9.1.9",
     "vite-hot-client": "^0.2.3",

--- a/packages/client/src/composables/shiki.ts
+++ b/packages/client/src/composables/shiki.ts
@@ -1,5 +1,5 @@
 import type { BuiltinLanguage, HighlighterCore } from 'shiki'
-import { getHighlighterCore } from 'shiki/core'
+import { createHighlighterCore } from 'shiki/core'
 import getWasm from 'shiki/wasm'
 
 export const shiki = shallowRef<HighlighterCore>()
@@ -9,7 +9,7 @@ let promise: Promise<any> | null = null
 export function renderCodeHighlight(code: string, lang: BuiltinLanguage | 'text' = 'text') {
   if (!promise && !shiki.value) {
     // Only loading when needed
-    promise = getHighlighterCore({
+    promise = createHighlighterCore({
       themes: [
         import('shiki/themes/vitesse-dark.mjs'),
         import('shiki/themes/vitesse-light.mjs'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       shiki:
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: ^1.9.0
+        version: 1.9.0
       splitpanes:
         specifier: ^3.1.5
         version: 3.1.5
@@ -269,8 +269,8 @@ importers:
         specifier: ^9.0.4
         version: 9.0.4
       shiki:
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: ^1.9.0
+        version: 1.9.0
       splitpanes:
         specifier: ^3.1.5
         version: 3.1.5
@@ -2697,8 +2697,8 @@ packages:
   '@shikijs/core@1.6.3':
     resolution: {integrity: sha512-QnJKHFUW95GnlJLJGP6QLx4M69HM0KlXk+R2Y8lr/x4nAx1Yb/lsuxq4XwybuUjTxbJk+BT0g/kvn0bcsjGGHg==}
 
-  '@shikijs/core@1.7.0':
-    resolution: {integrity: sha512-O6j27b7dGmJbR3mjwh/aHH8Ld+GQvA0OQsNO43wKWnqbAae3AYXrhFyScHGX8hXZD6vX2ngjzDFkZY5srtIJbQ==}
+  '@shikijs/core@1.9.0':
+    resolution: {integrity: sha512-cbSoY8P/jgGByG8UOl3jnP/CWg/Qk+1q+eAKWtcrU3pNoILF8wTsLB0jT44qUBV8Ce1SvA9uqcM9Xf+u3fJFBw==}
 
   '@shikijs/transformers@1.6.2':
     resolution: {integrity: sha512-ndqTWyHnxmsLkowhKWTam26opw8hg5a34y6FAUG/Xf6E49n3MM//nenKxXiWpPYkNPl1KZnYXB1k+Ia46wjOZg==}
@@ -7585,11 +7585,8 @@ packages:
   shiki@1.6.2:
     resolution: {integrity: sha512-X3hSm5GzzBd/BmPmGfkueOUADLyBoZo1ojYQXhd+NU2VJn458yt4duaS0rVzC+WtqftSV7mTVvDw+OB9AHi3Eg==}
 
-  shiki@1.6.3:
-    resolution: {integrity: sha512-lE1/YGlzFY0hQSyEfsZj18xGrTWxyhFQkaiILALqTBZPbJeYFWpbUhlmTGPOupYB/qC+H6sV4UznJzcEh3WMHQ==}
-
-  shiki@1.7.0:
-    resolution: {integrity: sha512-H5pMn4JA7ayx8H0qOz1k2qANq6mZVCMl1gKLK6kWIrv1s2Ial4EmD4s4jE8QB5Dw03d/oCQUxc24sotuyR5byA==}
+  shiki@1.9.0:
+    resolution: {integrity: sha512-i6//Lqgn7+7nZA0qVjoYH0085YdNk4MC+tJV4bo+HgjgRMJ0JmkLZzFAuvVioJqLkcGDK5GAMpghZEZkCnwxpQ==}
 
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -10743,7 +10740,7 @@ snapshots:
 
   '@shikijs/core@1.6.3': {}
 
-  '@shikijs/core@1.7.0': {}
+  '@shikijs/core@1.9.0': {}
 
   '@shikijs/transformers@1.6.2':
     dependencies:
@@ -16417,13 +16414,9 @@ snapshots:
     dependencies:
       '@shikijs/core': 1.6.2
 
-  shiki@1.6.3:
+  shiki@1.9.0:
     dependencies:
-      '@shikijs/core': 1.6.3
-
-  shiki@1.7.0:
-    dependencies:
-      '@shikijs/core': 1.7.0
+      '@shikijs/core': 1.9.0
 
   side-channel@1.0.4:
     dependencies:
@@ -17378,7 +17371,7 @@ snapshots:
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
-      shiki: 1.6.3
+      shiki: 1.9.0
       vite: 5.2.13(@types/node@20.14.5)(sass@1.77.6)(terser@5.26.0)
       vue: 3.4.29(typescript@5.4.5)
     optionalDependencies:


### PR DESCRIPTION
I don't now why it was locked as a fixed version, but there should not be any breaking changes for that. Current version range would cause Nuxt DevTools to have multiple version of Shiki installed