### PR TITLE
fix(client): hide state field display on edit

### DIFF
--- a/packages/applet/src/components/state/StateFieldViewer.vue
+++ b/packages/applet/src/components/state/StateFieldViewer.vue
@@ -204,14 +204,16 @@ async function submitDrafting() {
       </span>
       <span mx1>:</span>
       <StateFieldInputEditor v-if="editing" v-model="editingText" :custom-type="raw.customType" @cancel="toggleEditing" @submit="submit" />
-      <span :class="stateFormatClass" class="flex whitespace-nowrap">
-        <span class="flex" v-html="normalizedDisplayedValue" />
-      </span>
-      <StateFieldEditor
-        :hovering="isHovering" :disable-edit="state.disableEdit"
-        :data="data" :depth="depth" @enable-edit-input="toggleEditing"
-        @add-new-prop="addNewProp"
-      />
+      <template v-if="!editing">
+        <span :class="stateFormatClass" class="flex whitespace-nowrap">
+          <span class="flex" v-html="normalizedDisplayedValue" />
+        </span>
+        <StateFieldEditor
+          :hovering="isHovering" :disable-edit="state.disableEdit"
+          :data="data" :depth="depth" @enable-edit-input="toggleEditing"
+          @add-new-prop="addNewProp"
+        />
+      </template>
     </div>
     <div v-if="hasChildren && expanded.includes(`${depth}-${index}`)">
       <ChildStateViewer :data="normalizedDisplayedChildren" :depth="depth" :index="index" />


### PR DESCRIPTION
Before:

![image](https://github.com/vuejs/devtools-next/assets/16526639/16e66d0c-7101-4462-85fb-087ea28511ff)

After:

![image](https://github.com/vuejs/devtools-next/assets/16526639/5b7383e9-0d33-418e-a79e-d54d17fb2950)

Closes #506 