### PR TITLE
feat: group assets in duplicate paths between root and public by relativePath

### DIFF
--- a/packages/client/src/pages/assets.vue
+++ b/packages/client/src/pages/assets.vue
@@ -44,7 +44,7 @@ const filtered = computed(() => {
 const byFolders = computed(() => {
   const result: Record<string, AssetInfo[]> = {}
   for (const asset of filtered.value) {
-    const folder = `${asset.path.split('/').slice(0, -1).join('/')}/`
+    const folder = `${asset.relativePath.split('/').slice(0, -1).join('/')}/`
     if (!result[folder])
       result[folder] = []
     result[folder].push(asset)
@@ -71,7 +71,7 @@ const byTree = computed(() => {
   }
 
   filtered.value.forEach((file) => {
-    const pathParts = file.path.split('/').filter(part => part !== '')
+    const pathParts = file.relativePath.split('/').filter(part => part !== '')
     addToTree(root, pathParts, file)
   })
 

--- a/packages/core/src/rpc/types.ts
+++ b/packages/core/src/rpc/types.ts
@@ -6,6 +6,7 @@ export interface AssetInfo {
   path: string
   type: AssetType
   publicPath: string
+  relativePath: string
   filePath: string
   size: number
   mtime: number

--- a/packages/playground/basic/assets/asset-in-root-assets.md
+++ b/packages/playground/basic/assets/asset-in-root-assets.md
@@ -1,0 +1,1 @@
+# asset-in-root-assets

--- a/packages/playground/basic/public/assets/asset-in-public-assets.md
+++ b/packages/playground/basic/public/assets/asset-in-public-assets.md
@@ -1,0 +1,1 @@
+# asset-in-public-assets

--- a/packages/vite/src/rpc/assets.ts
+++ b/packages/vite/src/rpc/assets.ts
@@ -3,7 +3,7 @@ import { debounce } from 'perfect-debounce'
 import { getViteRpcServer } from '@vue/devtools-kit'
 import type { AssetImporter, AssetInfo, AssetType, ImageMeta, ViteRPCFunctions } from '@vue/devtools-core'
 import fg from 'fast-glob'
-import { join, resolve } from 'pathe'
+import { join, relative, resolve } from 'pathe'
 import { imageMeta } from 'image-meta'
 import { RpcFunctionCtx } from './types'
 
@@ -63,6 +63,11 @@ export function getAssetsFunctions(ctx: RpcFunctionCtx) {
   async function scan() {
     const dir = resolve(config.root)
     const baseURL = config.base
+
+    // publicDir in ResolvedConfig is an absolute path
+    const publicDir = config.publicDir
+    const relativePublicDir = publicDir === '' ? '' : `${relative(dir, publicDir)}/`
+
     const files = await fg([
       // image
       '**/*.(png|jpg|jpeg|gif|svg|webp|avif|ico|bmp|tiff)',
@@ -93,7 +98,7 @@ export function getAssetsFunctions(ctx: RpcFunctionCtx) {
       const filePath = resolve(dir, relativePath)
       const stat = await fsp.lstat(filePath)
       // remove public prefix to resolve vite assets warning
-      const path = relativePath.startsWith('public/') ? relativePath.slice(7) : relativePath
+      const path = relativePath.replace(relativePublicDir, '')
       return {
         path,
         relativePath,

--- a/packages/vite/src/rpc/assets.ts
+++ b/packages/vite/src/rpc/assets.ts
@@ -89,16 +89,17 @@ export function getAssetsFunctions(ctx: RpcFunctionCtx) {
       ],
     })
 
-    cache = await Promise.all(files.map(async (path) => {
-      const filePath = resolve(dir, path)
+    cache = await Promise.all(files.map(async (relativePath) => {
+      const filePath = resolve(dir, relativePath)
       const stat = await fsp.lstat(filePath)
       // remove public prefix to resolve vite assets warning
-      path = path.startsWith('public/') ? path.slice(7) : path
+      const path = relativePath.startsWith('public/') ? relativePath.slice(7) : relativePath
       return {
         path,
+        relativePath,
         publicPath: join(baseURL, path),
         filePath,
-        type: guessType(path),
+        type: guessType(relativePath),
         size: stat.size,
         mtime: stat.mtimeMs,
       }


### PR DESCRIPTION
# description

This PR is to close #510.

Todolist

- [x] add `relativePath` in `AssetInfo`
- [x] grid view
- [x] list view