### PR TITLE
Add instructions for opening/repositioning devtools.

### DIFF
--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -1,6 +1,8 @@
 # Features
 
-Discover all the features of the Vue DevTools
+After installation, you should see a small icon with the "Vue" logo at the bottom center of your screen. Clicking this(or pressing the "Toggle Vue DevTools" hotkey -- check your startup logs) will open the the Vue DevTools window.
+
+The Vue DevTools can be repositioned by dragging this icon.
 
 ## Overview
 


### PR DESCRIPTION
I just waited a bunch of time trying to figure out something that should be pretty fundamental to usage. In my opinion the docs should start with this text. 

(Removes "Discover all the features of the Vue DevTools" which feels like placeholder text anyway to have something before the first subheading.)

It would be nice to include the shortcut keys here but I know there's handling for Mac/non-Mac keyboards so I dunno how people would like that handled.