### PR TITLE
feat(client): truncate button add title attribute

### DIFF
--- a/packages/client/src/components/graph/GraphDrawer.vue
+++ b/packages/client/src/components/graph/GraphDrawer.vue
@@ -62,7 +62,7 @@ const keys = [
             }" @click="copy(data.name)"
           />
         </span>
-        <button hover="underline" truncate text-left text-gray-500 @click="_openInEditor(data!.path)">
+        <button hover="underline" truncate text-left text-gray-500 :title="data?.displayPath" @click="_openInEditor(data!.path)">
           {{ data?.displayPath }}
         </button>
       </div>


### PR DESCRIPTION
When the file path is long, ellipsis appears, making it difficult to view the complete file path.