### PR TITLE
docs: use `@wxt-dev/module-vue` instead of `@vitejs/plugin-vue` in faq

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -85,13 +85,12 @@ export default defineConfig({
 ```ts
 // wxt.config.ts
 import { defineConfig } from 'wxt'
-import vue from '@vitejs/plugin-vue'
 import devtools from 'vite-plugin-vue-devtools'
 
 export default defineConfig({
+  modules: ['@wxt-dev/module-vue'],
   vite: () => ({
     plugins: [
-      vue(),
       devtools({
         // your app entrypoint (wherever you call createApp())
         appendTo: '/entrypoints/popup/main.ts',


### PR DESCRIPTION
WXT has [preconfigured module](https://wxt.dev/guide/key-concepts/frontend-frameworks.html#built-in-modules) for Vue, which is more suitable than `@vitejs/plugin-vue` here.