### PR TITLE
refactor(kit): refactor property checks

### DIFF
--- a/packages/devtools-kit/src/core/component/state/custom.ts
+++ b/packages/devtools-kit/src/core/component/state/custom.ts
@@ -1,5 +1,5 @@
 import type { InspectorState, customTypeEnums } from '../types'
-import { getComponentName, getInstanceName } from '../utils'
+import { ensurePropertyExists, getComponentName, getInstanceName } from '../utils'
 import { processInstanceState } from './process'
 import { escape, getSetupStateType, toRaw } from './util'
 
@@ -225,7 +225,11 @@ export function getObjectDetails(object: Record<string, any>) {
   if (isState) {
     const stateTypeName = info.computed ? 'Computed' : info.ref ? 'Ref' : info.reactive ? 'Reactive' : null
     const value = toRaw(info.reactive ? object : object._value)
-    const raw = object.effect?.raw?.toString() || object.effect?.fn?.toString()
+
+    const raw = ensurePropertyExists(object, 'effect')
+      ? object.effect?.raw?.toString() || object.effect?.fn?.toString()
+      : null
+
     return {
       _custom: {
         type: stateTypeName?.toLowerCase(),
@@ -236,7 +240,7 @@ export function getObjectDetails(object: Record<string, any>) {
     }
   }
 
-  if (typeof object.__asyncLoader === 'function') {
+  if (ensurePropertyExists(object, '__asyncLoader') && typeof object.__asyncLoader === 'function') {
     return {
       _custom: {
         type: 'component-definition' satisfies customTypeEnums,

--- a/packages/devtools-kit/src/core/component/state/is.ts
+++ b/packages/devtools-kit/src/core/component/state/is.ts
@@ -1,8 +1,16 @@
-export function isVueInstance(value: Record<string, unknown>) {
-  return value._ && Object.keys(value._).includes('vnode')
+import { ensurePropertyExists } from '../utils'
+
+export function isVueInstance(value: any) {
+  if (!ensurePropertyExists(value, '_')) {
+    return false
+  }
+  if (!isPlainObject(value._)) {
+    return false
+  }
+  return Object.keys(value._).includes('vnode')
 }
 
-export function isPlainObject(obj: unknown) {
+export function isPlainObject(obj: unknown): obj is object {
   return Object.prototype.toString.call(obj) === '[object Object]'
 }
 

--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -1,7 +1,7 @@
 import { camelize } from '@vue/devtools-shared'
 import type { VueAppInstance } from '../../../types'
 import type { InspectorState } from '../types'
-import { returnError } from '../utils'
+import { ensurePropertyExists, returnError } from '../utils'
 import { vueBuiltins } from './constants'
 import { getPropType, getSetupStateType, toRaw } from './util'
 
@@ -151,8 +151,8 @@ function processSetupState(instance: VueAppInstance) {
       let result: Partial<InspectorState>
 
       let isOtherType = typeof value === 'function'
-        || typeof value?.render === 'function' // Components
-        || typeof value?.__asyncLoader === 'function' // Components
+        || (ensurePropertyExists(value, 'render') && typeof value.render === 'function') // Components
+        || (ensurePropertyExists(value, '__asyncLoader') && typeof value.__asyncLoader === 'function') // Components
         || (typeof value === 'object' && value && ('setup' in value || 'props' in value)) // Components
         || /^v[A-Z]/.test(key) // Directives
 
@@ -161,7 +161,9 @@ function processSetupState(instance: VueAppInstance) {
 
         const { stateType, stateTypeName } = getStateTypeAndName(info)
         const isState = info.ref || info.computed || info.reactive
-        const raw = rawData.effect?.raw?.toString() || rawData.effect?.fn?.toString()
+        const raw = ensurePropertyExists(rawData, 'effect')
+          ? rawData.effect?.raw?.toString() || rawData.effect?.fn?.toString()
+          : null
 
         if (stateType)
           isOtherType = false

--- a/packages/devtools-kit/src/core/component/state/replacer.ts
+++ b/packages/devtools-kit/src/core/component/state/replacer.ts
@@ -98,7 +98,7 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
     else if (val.constructor?.name === 'Store' && '_wrappedGetters' in val) {
       return '[object Store]'
     }
-    else if (ensurePropertyExists(val, 'currentRoute')) {
+    else if (ensurePropertyExists(val, 'currentRoute', true)) {
       return '[object Router]'
     }
     const customDetails = getObjectDetails(val)

--- a/packages/devtools-kit/src/core/component/state/replacer.ts
+++ b/packages/devtools-kit/src/core/component/state/replacer.ts
@@ -1,3 +1,4 @@
+import { ensurePropertyExists } from '../utils'
 import { INFINITY, MAX_ARRAY_SIZE, MAX_STRING_SIZE, NAN, NEGATIVE_INFINITY, UNDEFINED } from './constants'
 import { getBigIntDetails, getComponentDefinitionDetails, getDateDetails, getFunctionDetails, getHTMLElementDetails, getInstanceDetails, getMapDetails, getObjectDetails, getRouterDetails, getSetDetails, getStoreDetails } from './custom'
 import { isVueInstance } from './is'
@@ -69,8 +70,7 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
     else if (proto === '[object Error]') {
       return `[native Error ${(val as Error).message}<>${(val as Error).stack}]`
     }
-    // @ts-expect-error skip type check
-    else if (val.state && val._vm) {
+    else if (ensurePropertyExists(val, 'state', true) && ensurePropertyExists(val, '_vm', true)) {
       return getStoreDetails(val)
     }
     else if (val.constructor && val.constructor.name === 'VueRouter') {
@@ -85,8 +85,7 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
       seenInstance?.set(val, depth!)
       return componentVal
     }
-    // @ts-expect-error skip type check
-    else if (typeof val.render === 'function') {
+    else if (ensurePropertyExists(val, 'render', true) && typeof val.render === 'function') {
       return getComponentDefinitionDetails(val)
     }
     else if (val.constructor && val.constructor.name === 'VNode') {
@@ -96,12 +95,10 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
     else if (typeof HTMLElement !== 'undefined' && val instanceof HTMLElement) {
       return getHTMLElementDetails(val)
     }
-    // @ts-expect-error skip type check
-    else if (val.constructor?.name === 'Store' && val._wrappedGetters) {
+    else if (val.constructor?.name === 'Store' && '_wrappedGetters' in val) {
       return '[object Store]'
     }
-    // @ts-expect-error skip type check
-    else if (val.currentRoute) {
+    else if (ensurePropertyExists(val, 'currentRoute')) {
       return '[object Router]'
     }
     const customDetails = getObjectDetails(val)

--- a/packages/devtools-kit/src/core/component/utils/index.ts
+++ b/packages/devtools-kit/src/core/component/utils/index.ts
@@ -138,3 +138,12 @@ export function getComponentInstance(appRecord: AppRecord, instanceId: string | 
   // @TODO: find a better way to handle it
   return instance || appRecord.instanceMap.get(':root')
 }
+
+// #542, should use 'in' operator to check if the key exists in the object
+export function ensurePropertyExists<R = Record<string, unknown>>(obj: unknown, key: string, skipObjCheck = false): obj is R {
+  return skipObjCheck
+    ? key in (obj as object)
+    : typeof obj === 'object' && obj !== null
+      ? key in obj
+      : false
+}

--- a/packages/devtools-kit/src/shared/transfer.ts
+++ b/packages/devtools-kit/src/shared/transfer.ts
@@ -47,13 +47,13 @@ function encode(data: unknown, replacer: Replacer | null, list: unknown[], seen:
     const keys = Object.keys(data)
     for (i = 0, l = keys.length; i < l; i++) {
       key = keys[i]
+      // fix vue warn for compilerOptions passing-options-to-vuecompiler-sfc
+      // @TODO: need to check if it will cause any other issues
+      if (key === 'compilerOptions')
+        return index
       value = data[key]
       const isVm = value != null && isObject(value, Object.prototype.toString.call(data)) && isVueInstance(value)
       try {
-        // fix vue warn for compilerOptions passing-options-to-vuecompiler-sfc
-        // @TODO: need to check if it will cause any other issues
-        if (key === 'compilerOptions')
-          return index
         if (replacer) {
           value = replacer.call(data, key, value, depth, seenVueInstance)
         }


### PR DESCRIPTION
closes #542, improve property check.

Benchmark:

- 1. [use typeof object === 'object' && object !== null](https://perf.link/#eyJpZCI6IjJuNGJzeWluY21mIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IG9iaiA9IHt9IiwidGVzdHMiOlt7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoidHlwZW9mIG9iaiA9PT0gJ29iamVjdCcgJiYgb2JqICE9PSBudWxsIiwicnVucyI6WzEyNzMxMDAwLDEwMjYwMDAsMTQ2MDkwMDAsMTU4MzAwMCwxMDc5MzAwMCwxOTYwMDAsNjMzMDAwMCw5MzM0MDAwLDE0ODAwMDAsMTExMzAwMDAsNjMyMDAwMCw4MDM2MDAwLDM3NDAwMDAsNTQ4OTAwMCw3NTY4MDAwLDU0MjgwMDAsNzQ1OTAwMCw5MTkwMDAwLDE0ODQwMDAsOTI1NzAwMCwxMDgzMDAwMCwxNDM1ODAwMCwxMTk0MjAwMCwxODYyMzAwMCwxNDg0MDAwLDExMTczMDAwLDkxODEwMDAsMjU2NjAwMCwxNzAwMzAwMCwyOTk3MDAwLDExNjk3MDAwLDgzOTYwMDAsODc0ODAwMCwxOTk3MTAwMCwyNzc4MDAwLDEyNTUyMDAwLDUwOTUwMDAsOTQ2MzAwMCwyMDAwMCwzNTUxMDAwLDEyMTk2MDAwLDEwMjg4MDAwLDE1NDA2MDAwLDQzODgwMDAsMTg3NDcwMDAsNTA4NjAwMCwxMDc5MzAwMCwxMTYwNDAwMCw4MjA3MDAwLDE0ODQwMDAsOTI0ODAwMCw2Nzc5MDAwLDUzNTAwMDAsMjExNDAwMCwxNjg3MDAwLDEzNTI4MDAwLDIyNDAwMDAsMTE3MjgwMDAsMTQ4NDAwMCw4MTQwMDAwLDIxNTgzMDAwLDYyMjYwMDAsNDE5MzAwMCw5NTEyMDAwLDU4MDYwMDAsNDE3MDAwMCwxNDEzNjAwMCw4MzU2MDAwLDEzMzI4MDAwLDkzNzMwMDAsMjY2NjAwMCw1MTE3MDAwLDQxNzEwMDAsNTk0MTAwMCw2MjI1MDAwLDIwOTM3MDAwLDE0OTM5MDAwLDc3NTMwMDAsMzY4MzAwMCwzNzM4MDAwLDcxNjMwMDAsMzY4MzAwMCwyODA3MDAwLDQ4NzQwMDAsNDc4MTAwMCwyMDUyMDAwLDQ2NTcwMDAsMTgwMjEwMDAsMTI3NjQwMDAsMTE4NTkwMDAsNTA2NDAwMCwxNTEyMDAwLDI3MTUwMDAsNDU4MzAwMCw0MzI2MDAwLDYwMDMwMDAsMTA0OTEwMDAsMjA2ODcwMDAsMTg0MDAwMCw0NjE3MDAwXSwib3BzIjo3ODI0NjAwfSx7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6Ik9iamVjdC5wcm90b3R5cGUudG9TdHJpbmcuY2FsbChvYmopID09PSAnW29iamVjdCBPYmplY3RdJyIsInJ1bnMiOlsxMTAzMTAwMCw2NzgwMDAsNzg4OTAwMCwxMjEwMDAwLDgyMzcwMDAsNjE5MDAwLDIyMDIwMDAsNDEyOTAwMCwxMTYxMDAwLDQ5MjIwMDAsNTIzODAwMCw2NzkwMDAwLDE2NzYwMDAsMzUyNzAwMCw1NDA1MDAwLDQyMDgwMDAsNTcwNjAwMCw2NzE0MDAwLDEyMTAwMDAsNjI0ODAwMCw3ODM3MDAwLDkwNTgwMDAsMTAzNDkwMDAsMTU3OTcwMDAsMTI5NTAwMCw4MTA0MDAwLDQ4NDEwMDAsMTc4MjAwMCwxMzY3NTAwMCwxNTMyMDAwLDk5MTkwMDAsNzY0NjAwMCw3NTE2MDAwLDE2OTY4MDAwLDEyMTAwMDAsMTAxNzEwMDAsODI1MDAwLDY3NzAwMDAsMTY2NzQwMDAsMTIxMDAwMCwxMDMwMDAwMCw4NjE3MDAwLDEzMjIwMDAwLDI1NzMwMDAsMTYzNTEwMDAsMzAzMTAwMCw3NTg3MDAwLDUyMjQwMDAsNjY2ODAwMCwxMjEwMDAwLDU3NjgwMDAsNTQ4OTAwMCw0MTMxMDAwLDEwNzIwMDAsMTIxMDAwMCwxMTAwNDAwMCw3NDUwMDAsOTkzNjAwMCwxMjEwMDAwLDQwMDQwMDAsMTk1ODEwMDAsMjY2NTAwMCwzNDg2MDAwLDkyOTMwMDAsMjgzMDAwMCwyNzI0MDAwLDEyOTg4MDAwLDkyMjgwMDAsMTEyOTQwMDAsNzkzNzAwMCwxNDEwMDAwLDEzNjIwMDAsMTIxMDAwMCwxMjEwMDAwLDQzMDYwMDAsMTI5MDAwLDEzMzg1MDAwLDQ5NTAwMDAsMTYwOTAwMCwyNjE1MDAwLDY1NDMwMDAsMjAzNzAwMCwxOTg1MDAwLDE5ODkwMDAsMTYwOTAwMCwxMjEwMDAwLDIyMzAwMDAsMTYzMjcwMDAsMTAwNjMwMDAsNjQ4MzAwMCwyNjk0MDAwLDM5MDAwMCwxMjEwMDAwLDMzNTIwMDAsMjgzMzAwMCw0NDEyMDAwLDg1OTEwMDAsMTU0NDUwMDAsNzI2MDAwLDEyMTAwMDBdLCJvcHMiOjU2Njg4MDB9XSwidXBkYXRlZCI6IjIwMjQtMDctMzFUMDc6MDA6NDIuNDIyWiJ9), faster than check Object tags.
- 2. [use `in` operator](https://perf.link/#eyJpZCI6IjJuNGJzeWluY21mIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IG9iaiA9IHt9IiwidGVzdHMiOlt7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoiJ2ZvbycgaW4gb2JqIiwicnVucyI6WzExMzg1MDAwLDExNjI3MDAwLDY5MTQwMDAsMTI0MTUwMDAsMTU2NzAwMCwxNTY3MDAwLDcyNjcwMDAsMjEwMDAsMTU2NzAwMCw5MjEyMDAwLDI1OTAwMDAsOTQyNjAwMCw4MjQ2MDAwLDI0MjIwMDAsMTA2ODAwMDAsNzA4NTAwMCwyOTY5MDAwLDE4MTg4MDAwLDE5NzIxMDAwLDY4MjgwMDAsNTE0NDAwMCw3NzUwMDAwLDEwMjE1MDAwLDcxNjAwMCwxMDE4ODAwMCw4Nzc1MDAwLDY3NDYwMDAsMTg1MjgwMDAsMTYzNzAwMCw5NjkzMDAwLDk4OTUwMDAsMTU2NzAwMCw4NTMwMDAwLDE3MjQzMDAwLDI1NTkwMDAsNjk5NDAwMCwyNzk2MDAwLDE1NjcwMDAsMTU2NzAwMCw0NDA3MDAwLDg3ODQwMDAsMTY0MDAwMCwzNjM1MDAwLDE3MzM4MDAwLDQwNDAwMCwxMDI5NTAwMCwzNzgxMDAwLDcxNTkwMDAsOTM5MDAwLDI2NDEwMDAsNjI3NjAwMCw0NDA5MDAwLDYyMzkwMDAsMTIzNzcwMDAsMTU2NzAwMCw4OTUwMDAwLDkwNTUwMDAsMzc0MTAwMCw2NzIwMDAsMTM4MzAwMCwxODcyMDAwLDk1MTEwMDAsMzYzNTAwMCw4NDUwMDAwLDM0ODkwMDAsODE3MzAwMCw2MjQxMDAwLDQyNzgwMDAsMzg5MzAwMCwxNDc4MDAwLDgxNjkwMDAsNzIyNzAwMCw4NTgyMDAwLDE1NjcwMDAsMTQ0NDgwMDAsMTQ1MjcwMDAsOTA0NzAwMCwxODk3MDAwMCw3OTkzMDAwLDE3MTQyMDAwLDM2MzMwMDAsMTIxMTYwMDAsMzk5MTAwMCw3MTg2MDAwLDE0MzQwMDAsMzUxNzAwMCw4NDc0MDAwLDcwNDcwMDAsMzM4NzAwMCw1NjcyMDAwLDE4MDQxMDAwLDM5MDcwMDAsMTE5MDcwMDAsMzYzODAwMCwxNTY3MDAwLDE1NjcwMDAsMjc2MjAwMCwxMTg0MTAwMCw5NzkwMDAwLDM1ODIwMDBdLCJvcHMiOjY4MzI1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAxMDAiLCJjb2RlIjoib2JqLmZvbyIsInJ1bnMiOlsxMTQzMDAwMCwxMTk4MzAwMCwzNjg4MDAwLDEzMjE4MDAwLDIwNzIwMDAsMTkyNDAwMCw2MTkxMDAwLDExNzkwMDAsMTExNjAwMCw5ODI4MDAwLDM4MDUwMDAsOTYzODAwMCw5OTk0MDAwLDIwOTI1MDAwLDExMzc3MDAwLDg0NzgwMDAsMzE3NzAwMCwxODg4MjAwMCwxMDEwMDAsNDg4NTAwMCwzMTU5MDAwLDI3ODEwMDAsMTA2MDYwMDAsODA0MDAwLDk0NDEwMDAsODEyMzAwMCw3MzI0MDAwLDE0Mjg3MDAwLDEyOTcwMDAsOTI0NDAwMCwxMDM2NDAwMCwzNDQ4MDAwLDg4OTYwMDAsMTY5OTkwMDAsMzUxODAwMCw0ODYzMDAwLDgyNDAwMCwyMzc0MDAwLDE1ODkwMDAsMjc0NjAwMCw2OTkzMDAwLDE1ODkwMDAsMjIzODAwMCwxNDIyOTAwMCwyMTYzMzAwMCw3ODkyMDAwLDM3OTUwMDAsNzkzNDAwMCwyMDMxMDAwMCwyNTUxMDAwLDQzOTAwMDAsMjA0NzAwMCw2OTgyMDAwLDE0ODU0MDAwLDE5NjcwMDAwLDgzMzcwMDAsOTIxMTAwMCw0MTM3MDAwLDc2ODAwMCwxMzY5MDAwLDE4OTAwMDAsNDQ0NTAwMCw0Mjg4MDAwLDY5NzUwMDAsMzY4MTAwMCw5MzU0MDAwLDUwNTcwMDAsMzYxMzAwMCwzMjgxMDAwLDE1MDYyMDAwLDc4NjMwMDAsMzg3MDAwMCwzNzEwMDAwLDIyMTE4MDAwLDE0MjMwMDAwLDE2ODAwMDAwLDkwMDUwMDAsNTE3MDAwLDkxMTEwMDAsMTg1NDcwMDAsMzkyNjAwMCw4NzA4MDAwLDMxNjcwMDAsNzQ1NTAwMCwxNDQ5MDAwLDM1MzgwMDAsODM1OTAwMCw3Mjg4MDAwLDIyMzUwMDAsMzY4MjAwMCwxOTMyNjAwMCw1NTIzMDAwLDcwNDEwMDAsMzg0ODAwMCwyMTYxMDAwLDE1ODkwMDAsMjQ3MjAwMCw4NTc0MDAwLDg3NjAwMDAsNDA3MzAwMF0sIm9wcyI6NzE0MDk4MH1dLCJ1cGRhdGVkIjoiMjAyNC0wNy0zMVQwNzowMjoxNy4zNzVaIn0%3D), a little slow than directly access, but it worthy.