### PR TITLE
fix(vite): fix inspector short key failure

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -209,7 +209,6 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
   return [
     inspect as PluginOption,
     pluginOptions.componentInspector && VueInspector({
-      toggleComboKey: '',
       toggleButtonVisibility: 'never',
       launchEditor: pluginOptions.launchEditor,
       ...typeof pluginOptions.componentInspector === 'boolean'


### PR DESCRIPTION
hi~, I am working on #547 , but I found `vite-plugin-vue-inspector`'s [`toggleComboKey`](https://github.com/webfansplz/vite-plugin-vue-inspector) was set to `''`, this makes the default shortcut key for opening the inspector invalid.
When I removed it, `vite-plugin-vue-inspector`'s `toggleComboKey` is working!