### PR TITLE
fix(applet): intergration ui package's unocss style

### DIFF
--- a/packages/applet/src/index.ts
+++ b/packages/applet/src/index.ts
@@ -2,6 +2,7 @@ import 'uno.css'
 import '@unocss/reset/tailwind.css'
 import './styles/base.css'
 import '@vue/devtools-ui/style.css'
+import '@vue/devtools-ui/uno.css'
 
 export * from './modules/pinia'
 export * from './modules/components'


### PR DESCRIPTION
Currently, we highly depend on `unocss`, so we didn’t anticipate that someone would use `@vue/devtools-applet` without also using `unocss`. That causes the class names of `devtool-ui` to not be extracted.