### PR TITLE
chore: add .node-version

### DIFF
--- a/.node-version
+++ b/.node-version
@@ -1,0 +1,1 @@
+lts-latest


### PR DESCRIPTION
Let node version managers auto-switch to `lts-latest` node version.
