### PR TITLE
fix(iframe): add `credentialless` attribute

### DIFF
--- a/packages/overlay/src/composables/iframe.ts
+++ b/packages/overlay/src/composables/iframe.ts
@@ -9,6 +9,7 @@ export function useIframe(clientUrl: string, onLoad: () => void) {
     iframe.value.id = 'vue-devtools-iframe'
     iframe.value.src = clientUrl
     iframe.value.setAttribute('data-v-inspector-ignore', 'true')
+    iframe.value.setAttribute('credentialless', '')
     iframe.value.onload = onLoad
     return iframe.value
   }


### PR DESCRIPTION
When using the [WASM module](https://github.com/kleisauke/wasm-vips) to generate image previews, I faced some errors with showing iframe after setting this parameters to `server` inside `vite.config.js`

```ts
server: {
  headers: {
    'Cross-Origin-Embedder-Policy': 'require-corp',
    'Cross-Origin-Opener-Policy': 'same-origin',
  },
},
```

The fix for this was setting the `credentialless` attribute for all iframe; I think that we should add this to our `overlay/iframe`, too.

Chrome Blog: [link](https://developer.chrome.com/blog/iframe-credentialless)

Video Example:
https://github.com/user-attachments/assets/2fbce091-91fd-4fad-a948-7e24f081a0a9

