### PR TITLE
feat(kit): for better naming of `index.vue` components

### DIFF
--- a/packages/devtools-kit/src/core/component/utils/index.ts
+++ b/packages/devtools-kit/src/core/component/utils/index.ts
@@ -3,7 +3,11 @@ import { basename, classify } from '@vue/devtools-shared'
 import { Fragment } from '../../../shared/stub-vue'
 
 function getComponentTypeName(options: VueAppInstance['type']) {
-  return options.name || options._componentTag || options.__VUE_DEVTOOLS_COMPONENT_GUSSED_NAME__ || options.__name
+  const name = options.name || options._componentTag || options.__VUE_DEVTOOLS_COMPONENT_GUSSED_NAME__ || options.__name
+  if (name === 'index' && options.__file?.endsWith('index.vue')) {
+    return ''
+  }
+  return name
 }
 
 function getComponentFileName(options: VueAppInstance['type']) {

--- a/packages/playground/basic/src/components/IndexComponent/index.vue
+++ b/packages/playground/basic/src/components/IndexComponent/index.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const text = ref('Index')
+</script>
+
+<template>
+  <div>
+    {{ text }} Component
+  </div>
+</template>

--- a/packages/playground/basic/src/pages/Home.vue
+++ b/packages/playground/basic/src/pages/Home.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Foo from '../components/Foo.vue'
+import IndexComponent from '../components/IndexComponent/index.vue'
 
 const visible = ref(false)
 
@@ -23,6 +24,7 @@ const toRefObj = toRefs(obj)
   <div class="m-auto mt-3 h-80 w-120 flex flex-col items-center justify-center rounded bg-[#363636]">
     Home
     <Foo v-if="visible" />
+    <IndexComponent v-if="visible" />
     <img src="/vite.svg" alt="Vite Logo">
     <button class="w-30 cursor-pointer" @click="visible = !visible">
       Toggle Foo

--- a/packages/shared/src/general.ts
+++ b/packages/shared/src/general.ts
@@ -28,10 +28,12 @@ export function kebabize(str: string) {
 }
 
 export function basename(filename: string, ext: string): string {
-  const normalizedFilename = filename.replace(/^[a-z]:/i, '').replace(/\\/g, '/')
+  let normalizedFilename = filename.replace(/^[a-z]:/i, '').replace(/\\/g, '/')
+  if (normalizedFilename.endsWith(`index${ext}`)) {
+    normalizedFilename = normalizedFilename.replace(`/index${ext}`, ext)
+  }
   const lastSlashIndex = normalizedFilename.lastIndexOf('/')
   const baseNameWithExt = normalizedFilename.substring(lastSlashIndex + 1)
-
   if (ext) {
     const extIndex = baseNameWithExt.lastIndexOf(ext)
     return baseNameWithExt.substring(0, extIndex)


### PR DESCRIPTION
Similar to https://github.com/vuejs/devtools-v6/pull/1994

Sometimes developers have components nested inside directories and follow classic Node approach of naming them `/index.${extension}`, in this case `/index.vue`. Devtools currently display every component as `<Index>` unless you specify name. This PR will check for those components and use parent directory as component name.