### PR TITLE
fix(shared): add optional chain to `isInElectron` env

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -11,7 +11,7 @@ export const target = (typeof window !== 'undefined'
 
 export const isInChromePanel = typeof target.chrome !== 'undefined' && !!target.chrome.devtools
 export const isInIframe = isBrowser && target.self !== target.top
-export const isInElectron = typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('electron')
+export const isInElectron = typeof navigator !== 'undefined' && navigator.userAgent?.toLowerCase().includes('electron')
 // @ts-expect-error skip type check
 export const isNuxtApp = typeof window !== 'undefined' && !!window.__NUXT__
 export const isInSeparateWindow = !isInIframe && !isInChromePanel && !isInElectron


### PR DESCRIPTION
## Description
I have set-up a laravel, inertia and vue project and integrated devtools-next but kept getting errors on running vite:
```bash
failed to load config from {project dir}/vite.config.js
error when starting dev server:
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

## Solution
The first conditional in `isInElectron` checks if the navigator class exists, it does but it is empty - so the `userAgent` is undefined. I've added an optional chain to the end of the userAgent to ensure it's existence.