### PR TITLE
feat(client): show full text on hover for component state field viewer

### DIFF
--- a/packages/applet/src/components/state/StateFieldViewer.vue
+++ b/packages/applet/src/components/state/StateFieldViewer.vue
@@ -71,7 +71,7 @@ const normalizedDisplayedValue = computed(() => {
     const _value = type.value === 'custom' && !_type ? `"${displayedValue.value}"` : (displayedValue.value === '' ? `""` : displayedValue.value)
     const normalizedType = type.value === 'custom' && _type === 'ref' ? getInspectorStateValueType(_value) : type.value
     const selectText = type.value === 'string' ? 'select-text' : ''
-    const result = `<span class="${normalizedType}-state-type flex whitespace-nowrap ${selectText}">${_value}</span>`
+    const result = `<span title="${type.value === 'string' ? props.data.value : ''}" class="${normalizedType}-state-type flex whitespace-nowrap ${selectText}">${_value}</span>`
 
     if (extraDisplayedValue)
       return `${result} <span class="text-gray-500">(${extraDisplayedValue})</span>`


### PR DESCRIPTION
This PR slightly improves UX for string value inspect. 

Currently sometimes when text is too long and may contains multiple line, it's a bit inconvenient to inspect the whole value. 

This PR adds `title` attribute to solve this.


https://github.com/user-attachments/assets/906abbd5-5b67-401b-9748-ba42fbc67815

