### PR TITLE
chore: fix typo for toggle timeline layer visibility

### DIFF
--- a/packages/client/src/components/timeline/TimelineLayers.vue
+++ b/packages/client/src/components/timeline/TimelineLayers.vue
@@ -84,7 +84,7 @@ function toggleTimelineLayerEnabled(id: string) {
       >
         {{ item.label }}
         <span class="absolute right-2 rounded-1 bg-primary-500 px1 text-3 text-white op0 [.active_&]:(bg-primary-400 dark:bg-gray-600) group-hover:op80 hover:op100!" @click.stop="toggleTimelineLayerEnabled(item.id)">
-          {{ getTimelineLayerEnabled(item.id) ? 'Disabled' : 'Enabled' }}
+          {{ getTimelineLayerEnabled(item.id) ? 'Disable' : 'Enable' }}
         </span>
       </li>
     </ul>


### PR DESCRIPTION
Currently, the toggle shows the state of the layer after a click. In other words, it shows the opposite of the current state.

With this, the toggle shows the action when clicked.